### PR TITLE
significanthobbies: respect zero recommendation limits

### DIFF
--- a/src/lib/recommendations.test.ts
+++ b/src/lib/recommendations.test.ts
@@ -31,6 +31,11 @@ describe("getRecommendations", () => {
       const results = getRecommendations([], 3);
       expect(results.length).toBe(3);
     });
+
+    it("returns no results when limit is zero", () => {
+      const results = getRecommendations([], 0);
+      expect(results).toEqual([]);
+    });
   });
 
   describe("single hobby", () => {

--- a/src/lib/recommendations.ts
+++ b/src/lib/recommendations.ts
@@ -10,6 +10,8 @@ export type RecommendedHobby = {
 };
 
 export function getRecommendations(phases: Phase[], limit = 8): RecommendedHobby[] {
+  if (limit <= 0) return [];
+
   // Collect all unique hobbies (case-insensitive)
   const userHobbiesLower = new Set<string>();
   for (const phase of phases) {


### PR DESCRIPTION
## Findings
- `getRecommendations([], 0)` returned one starter recommendation instead of an empty list.
- The empty-profile path pushed before checking `limit`, so zero or negative limits were not respected.

## Fix
- Added an early `limit <= 0` return in `src/lib/recommendations.ts`.
- Added a regression test in `src/lib/recommendations.test.ts`.

## Checks
- `pnpm test -- src/lib/recommendations.test.ts`
- Pre-push `eslint .` hook completed successfully during `git push`.

## Residual risk
- Repo-wide lint still reports pre-existing warnings unrelated to this change; no errors were introduced by the patch.
