### PR TITLE
significanthobbies: handle malformed hobby slugs safely

### DIFF
--- a/src/app/hobbies/[hobby]/page.tsx
+++ b/src/app/hobbies/[hobby]/page.tsx
@@ -12,6 +12,7 @@ import { getRelatedHobbies } from "~/lib/hobby-affinities";
 import { getResourcesForHobby } from "~/lib/hobby-resources";
 import { getRoadmapForHobby } from "~/lib/hobby-roadmap";
 import { getTimelineUrl } from "~/lib/timeline-url";
+import { safeDecodeURIComponent } from "~/lib/slug";
 import type { Phase } from "~/lib/types";
 import { getServerAuthSession } from "~/server/auth";
 import { db } from "~/server/db";
@@ -37,7 +38,9 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props) {
   const { hobby } = await params;
-  const name = slugToHobby(decodeURIComponent(hobby));
+  const decoded = safeDecodeURIComponent(hobby);
+  if (!decoded) return {};
+  const name = slugToHobby(decoded);
   return {
     title: `${name} — SignificantHobbies`,
     description: `Explore ${name} — see community timelines, find tools and resources, and discover related hobbies on SignificantHobbies.`,
@@ -46,7 +49,9 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function HobbyDetailPage({ params }: Props) {
   const { hobby: hobbySlug } = await params;
-  const hobbyName = slugToHobby(decodeURIComponent(hobbySlug));
+  const decoded = safeDecodeURIComponent(hobbySlug);
+  if (!decoded) notFound();
+  const hobbyName = slugToHobby(decoded);
 
   const category = getCategoryForHobby(hobbyName);
   if (!category) notFound();

--- a/src/app/hobbies/[hobby]/page.tsx
+++ b/src/app/hobbies/[hobby]/page.tsx
@@ -1,4 +1,4 @@
-import { desc,eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -7,12 +7,12 @@ import { JsonLd } from "~/components/json-ld";
 import { Badge } from "~/components/ui/badge";
 import { timelines, users } from "~/db/schema";
 import { blogPosts } from "~/lib/blog-posts";
-import { getCategoryForHobby,HOBBY_CATEGORIES } from "~/lib/hobbies";
+import { getCategoryForHobby, HOBBY_CATEGORIES } from "~/lib/hobbies";
 import { getRelatedHobbies } from "~/lib/hobby-affinities";
 import { getResourcesForHobby } from "~/lib/hobby-resources";
 import { getRoadmapForHobby } from "~/lib/hobby-roadmap";
-import { getTimelineUrl } from "~/lib/timeline-url";
 import { safeDecodeURIComponent } from "~/lib/slug";
+import { getTimelineUrl } from "~/lib/timeline-url";
 import type { Phase } from "~/lib/types";
 import { getServerAuthSession } from "~/server/auth";
 import { db } from "~/server/db";

--- a/src/lib/slug.test.ts
+++ b/src/lib/slug.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { safeDecodeURIComponent } from "./slug";
+
+describe("safeDecodeURIComponent", () => {
+  it("decodes valid encoded strings", () => {
+    expect(safeDecodeURIComponent("rock%20climbing")).toBe("rock climbing");
+  });
+
+  it("returns null for malformed encodings", () => {
+    expect(safeDecodeURIComponent("%E0%A4%A")).toBeNull();
+  });
+});

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,7 @@
+export function safeDecodeURIComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Findings
- The hobby detail route called `decodeURIComponent()` directly on the path param.
- A malformed percent-encoded slug could throw before the page reached `notFound()`.

## Fix
- Added a tiny `safeDecodeURIComponent()` helper that returns `null` on malformed input.
- Wired the hobby metadata and detail page through the helper and fall back cleanly.
- Added a regression test for valid and malformed slugs.

## Checks
- `pnpm test -- src/lib/slug.test.ts`

## Residual risk
- This only hardens the hobby detail route. The rest of the repo still has unrelated pre-existing lint warnings.
