### PR TITLE
perf: fix N+1 queries, add indexes, enable ISR + edge cache

### DIFF
--- a/src/app/api/hobbies/route.ts
+++ b/src/app/api/hobbies/route.ts
@@ -20,7 +20,7 @@ export function GET() {
     },
     {
       headers: {
-        "Cache-Control": "public, max-age=86400",
+        "Cache-Control": "public, max-age=86400, s-maxage=86400",
       },
     },
   );

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,6 +1,6 @@
 export const revalidate = 300;
 
-import { count,desc, eq } from "drizzle-orm";
+import { count,desc, eq, inArray } from "drizzle-orm";
 import Link from "next/link";
 
 import { likes, timelines, users } from "~/db/schema";
@@ -37,17 +37,18 @@ export default async function ExplorePage() {
     .orderBy(desc(timelines.updatedAt))
     .limit(100);
 
-  // Get like counts for these timelines
+  // Get like counts for these timelines — single GROUP BY query instead of
+  // one COUNT(*) per timeline (N+1 → 1).
   const timelineIds = rawTimelines.map((t) => t.id);
   const likeCounts: Record<string, number> = {};
   if (timelineIds.length > 0) {
-    for (const t of rawTimelines) {
-      const [result] = await db
-        .select({ count: count() })
-        .from(likes)
-        .where(eq(likes.timelineId, t.id));
-      likeCounts[t.id] = result?.count ?? 0;
-    }
+    const likeCountRows = await db
+      .select({ timelineId: likes.timelineId, count: count() })
+      .from(likes)
+      .where(inArray(likes.timelineId, timelineIds))
+      .groupBy(likes.timelineId);
+    for (const lc of likeCountRows) likeCounts[lc.timelineId] = lc.count;
+    // timelines with no likes default to 0
   }
 
   const timelineList: (TimelineData & { likeCount: number })[] = rawTimelines.map((raw) => {

--- a/src/app/hobbies/[hobby]/page.tsx
+++ b/src/app/hobbies/[hobby]/page.tsx
@@ -28,6 +28,8 @@ function slugToHobby(slug: string): string {
     .join(" ");
 }
 
+export const revalidate = 3600; // 1 hour ISR
+
 export async function generateStaticParams() {
   return HOBBY_CATEGORIES.flatMap((c) =>
     c.hobbies.map((h) => ({

--- a/src/app/timeline/[id]/page.tsx
+++ b/src/app/timeline/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { asc,eq } from "drizzle-orm";
+import { asc,eq, inArray } from "drizzle-orm";
 import { ArrowLeft, Pencil, User } from "lucide-react";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
@@ -122,15 +122,16 @@ export default async function TimelinePage({ params }: Props) {
     .where(eq(commentsTable.timelineId, raw.id))
     .orderBy(asc(commentsTable.createdAt));
 
-  // Fetch comment users
+  // Fetch comment users — single inArray query instead of one findFirst per
+  // user (N+1 → 1).
   const commentUserIds = [...new Set(commentRows.map((c) => c.userId))];
-  const commentUsersMap: Record<string, { name: string | null; username: string | null; image: string | null }> = {};
-  for (const uid of commentUserIds) {
-    const u = await db.query.users.findFirst({
-      where: eq(users.id, uid),
-      columns: { name: true, username: true, image: true },
+  const commentUsersMap: Record<string, { id: string; name: string | null; username: string | null; image: string | null }> = {};
+  if (commentUserIds.length > 0) {
+    const commentUsers = await db.query.users.findMany({
+      where: inArray(users.id, commentUserIds),
+      columns: { id: true, name: true, username: true, image: true },
     });
-    if (u) commentUsersMap[uid] = u;
+    for (const u of commentUsers) commentUsersMap[u.id] = u;
   }
 
   // Which comments belong to the current user (drives delete button visibility)

--- a/src/app/u/[username]/[slug]/page.tsx
+++ b/src/app/u/[username]/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { asc,eq } from "drizzle-orm";
+import { asc,eq, inArray } from "drizzle-orm";
 import { ArrowLeft, Pencil, User } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -133,15 +133,16 @@ export default async function TimelineBySlugPage({ params }: Props) {
     .where(eq(commentsTable.timelineId, raw.id))
     .orderBy(asc(commentsTable.createdAt));
 
-  // Fetch comment users
+  // Fetch comment users — single inArray query instead of one findFirst per
+  // user (N+1 → 1).
   const commentUserIds = [...new Set(commentRows.map((c) => c.userId))];
-  const commentUsersMap: Record<string, { name: string | null; username: string | null; image: string | null }> = {};
-  for (const uid of commentUserIds) {
-    const u = await db.query.users.findFirst({
-      where: eq(users.id, uid),
-      columns: { name: true, username: true, image: true },
+  const commentUsersMap: Record<string, { id: string; name: string | null; username: string | null; image: string | null }> = {};
+  if (commentUserIds.length > 0) {
+    const commentUsers = await db.query.users.findMany({
+      where: inArray(users.id, commentUserIds),
+      columns: { id: true, name: true, username: true, image: true },
     });
-    if (u) commentUsersMap[uid] = u;
+    for (const u of commentUsers) commentUsersMap[u.id] = u;
   }
 
   const ownCommentIds = new Set(

--- a/src/components/timeline-view/comments-section.tsx
+++ b/src/components/timeline-view/comments-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Trash2 } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -44,9 +45,11 @@ function timeAgo(date: Date): string {
 function Avatar({ user }: { user: Comment["user"] }) {
   if (user.image) {
     return (
-      <img
+      <Image
         src={user.image}
         alt={user.name ?? "User"}
+        width={32}
+        height={32}
         className="h-8 w-8 rounded-full object-cover shrink-0 border border-stone-200"
       />
     );

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -145,6 +145,7 @@ export const timelines = sqliteTable(
   (table) => [
     index("Timeline_userId_idx").on(table.userId),
     index("Timeline_slug_idx").on(table.slug),
+    index("Timeline_visibility_idx").on(table.visibility),
   ],
 );
 


### PR DESCRIPTION
## Summary
- **explore page**: Replace N+1 like-count `COUNT(*)` loop with single `GROUP BY` query using `inArray` (~50-100x fewer queries on 100 timelines)
- **timeline/[id] + u/[username]/[slug]**: Replace N+1 comment-user `findFirst` loop with single `findMany` using `inArray`
- **schema**: Add `Timeline_visibility_idx` index on `timelines.visibility`
- **hobbies/[hobby]**: Add `revalidate = 3600` (1h ISR)
- **api/hobbies**: Add `s-maxage=86400` to `Cache-Control` for edge caching
- **comments-section**: Use `next/image` `<Image>` for comment avatars instead of raw `<img>`

#### Verification
- [ ] `pnpm build` / typecheck passes
- [ ] `pnpm test` passes
- [ ] `pnpm db:push` applies the new index

Generated with [Devin](https://devin.ai)