### PR TITLE
fix: compile Tailwind for Astro landing (prod CSS broken via /tailwindcss 404)

### DIFF
--- a/landing-astro/src/layouts/Layout.astro
+++ b/landing-astro/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import landingStyles from '@/styles/landing.css?raw';
+import '@/styles/landing.css';
 
 interface Props {
   title: string;
@@ -95,7 +95,5 @@ const OG_IMAGE = `${SITE_URL}/opengraph-image`;
       })();
     </script>
     <slot />
-    {/* Tailwind at body-end so the parser reaches #lcp-shell after ~2KB head, not ~22KB. */}
-    <style is:inline set:html={landingStyles} />
   </body>
 </html>


### PR DESCRIPTION
## Problem
Production `/` served fully unstyled. The Astro landing layout imported `landing.css?raw` and injected it with `set:html`, so `@tailwindcss/vite` never compiled it. The literal `@import "tailwindcss";` shipped to the browser, resolved to `/tailwindcss` → 404 HTML → `Refused to apply style ... MIME type ('text/html')`.

## Fix
Normal `import '@/styles/landing.css'` so Vite + the Tailwind plugin compile + content-scan the `.astro` components; Astro `inlineStylesheets: 'always'` inlines the compiled output. Body-end deferral hack dropped (the `#lcp-shell` critical inline style stays at top of head, LCP unaffected).

## Verification
`pnpm --filter ./landing-astro build` → `dist/index.html`:
- Compiled utilities present (`bg-stone-950`, `min-h-svh`, `text-5xl`, `.flex`)
- Zero literal `@import "tailwindcss"` / `/tailwindcss` link refs (only the Tailwind license-comment URL remains)
- Inlined `<style>` ~20KB, no `<link rel=stylesheet>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)