### PR TITLE
fix: unblock the deploy build, and stop the quiz prescribing running to everyone

### DIFF
--- a/src/app/find-your-hobby/quiz-client.tsx
+++ b/src/app/find-your-hobby/quiz-client.tsx
@@ -29,7 +29,7 @@ import { useEffect, useRef, useState } from 'react';
 import { FadeIn, SpotlightCard } from '~/components/aceternity';
 import { QuizResultCard } from '~/components/quiz-result-card';
 import { trackDiscovery, trackDiscoveryFunnel, trackEvent } from '~/lib/analytics';
-import { HOBBY_CATEGORIES } from '~/lib/hobbies';
+import { HOBBY_CATEGORIES, pickAcrossEffort } from '~/lib/hobbies';
 
 type Category =
   | 'Creative'
@@ -169,7 +169,10 @@ const ARCHETYPE_MAP: Record<Category, { title: string; emoji: string; descriptio
   Physical: {
     title: 'The Athlete',
     emoji: '🏆',
-    description: "You thrive when you're pushing your body and breaking limits.",
+    // Not "pushing your body and breaking limits": the Physical category is
+    // reached by anyone who wants to move, and that framing reads as a young
+    // person's gym slogan to most of the people it lands on.
+    description: 'You think best while moving. Your body is where you go to feel like yourself.',
   },
   Outdoor: {
     title: 'The Explorer',
@@ -224,7 +227,10 @@ function getRecommendedHobbies(topCats: Category[]): string[] {
   for (const cat of topCats.slice(0, 2)) {
     const found = HOBBY_CATEGORIES.find((c) => c.name === cat);
     if (found) {
-      results.push(...found.hobbies.slice(0, 3));
+      // Not `slice(0, 3)`: that returned the first three array entries and
+      // called it a personalised result, so every Physical answer produced
+      // Running / Cycling / Swimming. See pickAcrossEffort in ~/lib/hobbies.
+      results.push(...pickAcrossEffort(found.hobbies, 3));
     }
   }
   return results.slice(0, 6);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,7 +5,6 @@ import { timelines, users } from '~/db/schema';
 import { editorialArticles } from '~/lib/editorial-content';
 import { FAMOUS_BUCKET_LISTS } from '~/lib/famous-bucket-lists';
 import { HOBBY_CATEGORIES } from '~/lib/hobbies';
-import { captureError } from '~/lib/foundry-monitoring';
 import { db } from '~/server/db';
 
 export const revalidate = 3600;
@@ -48,7 +47,12 @@ async function publicProfileEntries(baseUrl: string): Promise<MetadataRoute.Site
         : []
     );
   } catch (err) {
-    captureError(err, { scope: 'sitemap', source: 'public_profiles' });
+    // Server-side log, not `captureError` from ~/lib/foundry-monitoring: that
+    // module is 'use client' and wraps posthog-js. Importing it here made the
+    // sitemap route a client boundary, and `next build` failed prerendering
+    // /sitemap.xml with "Attempted to call captureError() from the server".
+    // The whole deploy died at the build step because of it.
+    console.error('[sitemap] public_profiles query failed', err);
     return [];
   }
 }

--- a/src/lib/hobbies.test.ts
+++ b/src/lib/hobbies.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { HOBBY_CATEGORIES, getCategoryForHobby, isStrenuous, pickAcrossEffort } from './hobbies';
+
+const physical = HOBBY_CATEGORIES.find((c) => c.name === 'Physical');
+
+describe('pickAcrossEffort', () => {
+  it('never returns an all-strenuous set for the Physical category', () => {
+    const picked = pickAcrossEffort(physical?.hobbies ?? [], 3);
+    expect(picked).toHaveLength(3);
+    expect(picked.filter(isStrenuous).length).toBeLessThanOrEqual(1);
+  });
+
+  /**
+   * The regression. The quiz used `hobbies.slice(0, 3)`, so every visitor whose
+   * top category was Physical got Running / Cycling / Swimming regardless of
+   * their answers, and the first instruction rendered under it was "Do one tiny
+   * running session today" — served immediately after the mortality page.
+   */
+  it('does not open a Physical set with something strenuous', () => {
+    const picked = pickAcrossEffort(physical?.hobbies ?? [], 3);
+    expect(isStrenuous(picked[0])).toBe(false);
+    expect(picked[0]).not.toBe('Running');
+  });
+
+  it('leaves categories with nothing strenuous in their authored order', () => {
+    const intellectual = HOBBY_CATEGORIES.find((c) => c.name === 'Intellectual');
+    const hobbies = intellectual?.hobbies ?? [];
+    expect(pickAcrossEffort(hobbies, 3)).toEqual(hobbies.slice(0, 3));
+  });
+
+  it('still returns something when a category is entirely strenuous', () => {
+    const picked = pickAcrossEffort(['Running', 'Climbing', 'Surfing'], 3);
+    expect(picked).toHaveLength(3);
+  });
+
+  it('respects the limit', () => {
+    expect(pickAcrossEffort(physical?.hobbies ?? [], 2)).toHaveLength(2);
+  });
+});
+
+describe('catalog coverage for older visitors', () => {
+  /**
+   * These were all absent, so a visitor typing "Bridge" into the timeline hit
+   * `getCategoryForHobby` returning undefined, bucketed as "Other", and
+   * contributed nothing to their archetype or recommendations — their actual
+   * life was invisible to the engine.
+   */
+  it.each([
+    'Walking',
+    'Golf',
+    'Bridge',
+    'Crosswords',
+    'Genealogy',
+    'Tai chi',
+    'Choir',
+    'Quilting',
+    'Bowling',
+    'Mahjong',
+    'Sudoku',
+    'Pilates',
+  ])('%s is in the catalog and resolves to a category', (hobby) => {
+    expect(getCategoryForHobby(hobby), `${hobby} should be catalogued`).toBeDefined();
+  });
+
+  it('has no duplicate hobbies across categories', () => {
+    const all = HOBBY_CATEGORIES.flatMap((c) => c.hobbies).map((h) => h.toLowerCase());
+    expect(new Set(all).size).toBe(all.length);
+  });
+});

--- a/src/lib/hobbies.ts
+++ b/src/lib/hobbies.ts
@@ -17,6 +17,7 @@ export const HOBBY_CATEGORIES: HobbyCategory[] = [
       'Ceramics',
       'Knitting',
       'Crochet',
+      'Quilting',
       'Embroidery',
       'Sewing',
       'Origami',
@@ -50,18 +51,25 @@ export const HOBBY_CATEGORIES: HobbyCategory[] = [
     name: 'Physical',
     emoji: '💪',
     hobbies: [
+      'Walking',
       'Running',
       'Cycling',
       'Swimming',
       'Hiking',
       'Climbing',
       'Yoga',
+      'Tai chi',
+      'Pilates',
       'Gym',
       'Martial arts',
       'Dance',
+      'Golf',
+      'Bowling',
+      'Lawn bowls',
       'Basketball',
       'Football',
       'Tennis',
+      'Table tennis',
       'Skiing',
       'Skateboarding',
       'Surfing',
@@ -77,10 +85,14 @@ export const HOBBY_CATEGORIES: HobbyCategory[] = [
     emoji: '📚',
     hobbies: [
       'Reading',
+      'Crosswords',
       'Chess',
+      'Bridge',
+      'Genealogy',
       'Coding',
       'Language learning',
       'Puzzles',
+      'Sudoku',
       'Philosophy',
       'History',
       'Astronomy',
@@ -167,6 +179,8 @@ export const HOBBY_CATEGORIES: HobbyCategory[] = [
       'Volunteering',
       'Hosting dinners',
       'Book club',
+      'Choir',
+      'Mahjong',
       'Improv comedy',
       'Theater',
       'Debate club',
@@ -176,6 +190,62 @@ export const HOBBY_CATEGORIES: HobbyCategory[] = [
 ];
 
 export const ALL_HOBBIES = HOBBY_CATEGORIES.flatMap((c) => c.hobbies);
+
+/**
+ * Hobbies that ask a lot of the body. Used to keep a set of suggestions from
+ * being uniformly strenuous — not to hide anything from anyone.
+ *
+ * The quiz has no idea how old you are or what your knees are like, and it
+ * never asks. It used to answer with `hobbies.slice(0, 3)`, so everyone whose
+ * top category was Physical got Running, Cycling, Swimming — the first three
+ * array entries, presented as a personalised result. For a 70-year-old the
+ * first instruction after the mortality page was "Do one tiny running session
+ * today."
+ */
+const STRENUOUS = new Set([
+  'Running',
+  'Climbing',
+  'Martial arts',
+  'Basketball',
+  'Football',
+  'Skiing',
+  'Skateboarding',
+  'Surfing',
+  'Rowing',
+  'Scuba diving',
+  'Fencing',
+  'Gym',
+  'Tennis',
+  'Hiking',
+  'Dance',
+]);
+
+export function isStrenuous(hobby: string): boolean {
+  return STRENUOUS.has(hobby);
+}
+
+/**
+ * Up to `limit` hobbies from a category, never all-strenuous.
+ *
+ * At most one demanding option makes the cut, and it is never first — so a set
+ * always opens with something anyone could start this afternoon while still
+ * offering a stretch. Categories with nothing strenuous in them are unaffected
+ * and keep their authored order.
+ */
+export function pickAcrossEffort(hobbies: string[], limit = 3): string[] {
+  const gentle = hobbies.filter((h) => !isStrenuous(h));
+  const strenuous = hobbies.filter((h) => isStrenuous(h));
+  if (strenuous.length === 0) return hobbies.slice(0, limit);
+
+  const picked = gentle.slice(0, Math.max(1, limit - 1));
+  if (picked.length < limit && strenuous.length > 0) picked.push(strenuous[0]);
+  // Backfill from whatever is left if the category was mostly strenuous.
+  for (const h of hobbies) {
+    if (picked.length >= limit) break;
+    if (!picked.includes(h)) picked.push(h);
+  }
+  return picked.slice(0, limit);
+}
 
 export function getCategoryForHobby(hobby: string): HobbyCategory | undefined {
   const lower = hobby.toLowerCase();

--- a/src/lib/personality.ts
+++ b/src/lib/personality.ts
@@ -40,7 +40,7 @@ const ARCHETYPES: Record<string, Archetype> = {
     name: 'Action Hero',
     emoji: '⚡',
     description:
-      'You live in your body — outdoors, active, and always seeking the next physical challenge.',
+      'You live in your body — outdoors, active, and happiest when the day involves moving.',
   },
   mindBuilder: {
     name: 'Mind Builder',


### PR DESCRIPTION
## The deploy failed at the build step

Run [30189333069](https://github.com/Significant-Hobbies/significanthobbies/actions/runs/30189333069) died in `node scripts/cf-build.mjs`, prerendering `/sitemap.xml`:

> Attempted to call `captureError()` from the server but `captureError` is on the client.

**Nothing reached Cloudflare** — `wrangler` never ran, so production was untouched.

`src/app/sitemap.ts` imported `captureError` from `~/lib/foundry-monitoring`, which is `'use client'` and wraps `posthog-js`. The import alone is harmless; the *call* is not, and it only happens inside the catch around the public-profiles query. So the build passes wherever the database is reachable and fails wherever it is not — and the deploy workflow sets no `DATABASE_URL`.

That is why local builds were green every time. Reproduced exactly by pointing `DATABASE_URL` at an unreachable host, then confirmed the fix under the same conditions (`EXIT=0`, sitemap degrades to its static routes).

Introduced in `ff2f2bc`, not by this branch.

## The quiz recommended running to everyone

`getRecommendedHobbies` did `hobbies.slice(0, 3)` — the first three array entries, presented as a personalised result. Everyone whose top category was Physical got Running / Cycling / Swimming, and the generated first step read **"Do one tiny running session today."**

`/life-in-weeks` now sends people straight here, one click after showing them how many Saturdays they have left.

`pickAcrossEffort` keeps at most one strenuous option per set and never puts it first. Nothing is hidden, and no filtering is done on age — the quiz does not know anyone's age and still doesn't. Verified end to end: answering every active option now leads with *"Do one tiny walking session today"*, running third.

## Catalog

Added Walking, Golf, Bowling, Lawn bowls, Tai chi, Pilates, Table tennis, Bridge, Crosswords, Sudoku, Genealogy, Choir, Mahjong, Quilting.

All were missing, so `getCategoryForHobby` returned `undefined`, the timeline bucketed them as "Other", and they contributed nothing to anyone's archetype or recommendations — the hobbies an older visitor most likely already has were the ones the engine could not see.

## Checks

- 367 unit tests (18 new in `hobbies.test.ts`)
- 104/104 e2e, desktop + landing
- typecheck, lint, docs:check clean
- production build verified against an unreachable database

🤖 Generated with [Claude Code](https://claude.com/claude-code)