### PR TITLE
fix: one main landmark on /life-in-weeks, and record the deploy trap

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -130,11 +130,23 @@ and is genuinely public — that one is consistent.
 
 ## Next steps
 
-1. Apply `drizzle/0003_visibility_and_timezone.sql` to dev and production.
-2. Capture the 7-day PostHog quiz-funnel result, then freeze the winning
+1. **Nested `<main>` landmarks on 13 pages.** `app/layout.tsx` already wraps
+   every page in `<main id="main">`, and 13 route components render a second
+   `<main>` inside it, so assistive tech is offered a choice between two main
+   landmarks. Fixed on `/life-in-weeks` only. The axe check in
+   `content-flywheel.spec.ts` cannot catch it — it asserts on `main#main`,
+   which a nested unnamed `<main>` leaves at a count of one. Sweep the rest and
+   tighten that assertion to `page.locator('main')`.
+2. **Content for older visitors, remaining items.** The `/bucket-list-before-30`
+   copy ("before life narrows"), `/hobbies-for-resume` framing, the
+   `what-are-significant-hobbies` worked example ending at "career, now", and
+   the "Life journey" starter template in `src/lib/templates.ts` whose last
+   phase ends at age 28. None are linked from in-product navigation.
+3. Apply `drizzle/0003_visibility_and_timezone.sql` to dev and production.
+4. Capture the 7-day PostHog quiz-funnel result, then freeze the winning
    discovery path and pause feature development.
-3. Review and merge the content-flywheel branch after OpenSpec verification.
-4. **Make the journal an actual bridge.** `journalEntries` has no foreign key
+5. Review and merge the content-flywheel branch after OpenSpec verification.
+6. **Make the journal an actual bridge.** `journalEntries` has no foreign key
    beyond `userId`, so the product's headline claim is copy rather than code.
    Adding an optional hobby/timeline/commitment reference to a journal entry is
    the single highest-leverage change available: it makes the thesis true and

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -188,19 +188,30 @@ the result.
 
 Two failure modes cost the most to diagnose, both worth recognising on sight:
 
-**Filling a controlled input before hydration.** `await expect(field).toBeVisible()`
-does not mean React has hydrated. A `fill()` that lands first updates the DOM but
-not component state; hydration then reverts it, the form compares the value
-against its unchanged initial prop, skips the write, and still shows a success
-toast. It presents as "the save silently did nothing" and it is timing-dependent,
-so it flaps rather than fails. Retry the fill until it sticks:
+**Interacting before hydration.** `await expect(x).toBeVisible()` only proves the
+server HTML arrived. Acting before React attaches is silent, not loud, and it
+fails differently depending on the element:
+
+| Element | Symptom |
+| --- | --- |
+| Controlled input | `fill()` reaches the DOM but not state. Hydration reverts it, the form sees an unchanged value, skips the write, and still shows a success toast — "the save silently did nothing". |
+| Button | No handler yet, so the click does nothing and whatever it should reveal never appears. Surfaces one line later as "element not found". |
+
+Both reproduce only where the route pays a cold `next dev` compile — CI under
+two workers, almost never a warm local run. Use `waitForHydrated` from
+`e2e/fixtures/hydration.ts`, which polls for React's own
+`__reactFiber$…` / `__reactProps$…` keys rather than guessing a timeout:
 
 ```ts
-await expect(async () => {
-  await field.fill(value);
-  await expect(field).toHaveValue(value);
-}).toPass({ timeout: 15_000 });
+import { waitForHydrated } from './fixtures/hydration';
+
+await waitForHydrated(field);
+await field.fill(value);
 ```
+
+A retry-until-it-sticks loop was tried first and timed out in CI. For a toggle
+button, retrying is actively wrong — the second click closes what the first
+opened.
 
 **Reusing a fixed entity name.** `dev.db` survives between local runs. A spec
 that creates "Piano" every time hits `You already have an active commitment for

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -57,6 +57,31 @@ without a full deploy (e.g. hotfix the Astro overlay), purge manually.
 
 ## Failure modes
 
+### Deploy build fails but every local build passed
+
+**Symptom:** `deploy.yml` fails in `node scripts/cf-build.mjs` while
+`pnpm build` is green on your machine. `wrangler` never runs, so production is
+untouched — check the step list before assuming a partial deploy.
+
+**Cause:** the deploy job sets no `DATABASE_URL`. Anything that only executes
+when a database query *fails* is therefore unreachable locally and reached on
+every deploy. This bit once already: `sitemap.ts` called `captureError` from
+`~/lib/foundry-monitoring` inside the catch around its public-profiles query.
+That module is `'use client'`, so the build died with "Attempted to call
+captureError() from the server" — but only where the DB was unreachable.
+
+**Reproduce locally** — point the URL at a host that does not resolve, which
+makes every query throw the way it does in CI:
+
+```bash
+rm -rf .next
+DATABASE_URL="libsql://nonexistent-host-xyz.turso.io" pnpm build
+```
+
+**Rule:** server routes must not import from `'use client'` modules. An unused
+import is silently fine, which is what makes this class of bug survive review —
+the failure only appears on the path that calls it.
+
 ### Cloudflare 1015 rate-limit on homepage
 
 **Symptom:** `smoke.yml` reports HTTP 429 or 1015 on the homepage probe.

--- a/e2e/authenticated.spec.ts
+++ b/e2e/authenticated.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './fixtures/auth';
+import { waitForHydrated } from './fixtures/hydration';
 
 /**
  * First authenticated e2e coverage in this repo.
@@ -137,19 +138,9 @@ test.describe('authenticated surfaces', () => {
     // write, and still reports "Profile updated!". `toBeVisible()` only proves
     // the server HTML arrived.
     //
-    // Gated on React's own hydration marker rather than a timeout: React
-    // attaches `__reactFiber$…` / `__reactProps$…` keys to each host node as it
-    // hydrates. A retry-until-it-sticks loop worked locally but timed out in
-    // CI, where /settings cold-compiles under `next dev` with two workers and
-    // hydration lands far later than any budget worth hardcoding.
-    await authedPage.waitForFunction(
-      () => {
-        const el = document.getElementById('creed');
-        return !!el && Object.keys(el).some((k) => k.startsWith('__react'));
-      },
-      undefined,
-      { timeout: 60_000 }
-    );
+    // See waitForHydrated: a retry-until-it-sticks loop worked locally but timed
+    // out in CI, where /settings cold-compiles under two workers.
+    await waitForHydrated(field);
 
     await field.fill(creed);
     await expect(field).toHaveValue(creed);
@@ -184,10 +175,11 @@ test.describe('authenticated surfaces', () => {
     // fullyParallel against one dev.db, so two tests adding the same item title
     // would each see the other's row and the delete assertion would never settle.
     await authedPage.goto('/bucket-lists/richard-branson');
-    await authedPage
-      .getByRole('button', { name: /^Add .+ to my bucket list$/ })
-      .first()
-      .click();
+    const add = authedPage.getByRole('button', { name: /^Add .+ to my bucket list$/ }).first();
+    // Same hydration trap as the commitments trigger: an unhydrated click is
+    // silent, so the toast never fires and this reads as a broken add button.
+    await waitForHydrated(add);
+    await add.click();
     await expect(authedPage.getByText('Added to your bucket list').first()).toBeVisible();
 
     await authedPage.goto('/life-plan');
@@ -241,8 +233,14 @@ test.describe('authenticated surfaces', () => {
     // "passed" while stamping nothing. Each step waits for the effect of the one
     // before it — clicking a button is not the same as the action completing.
     // The creation form is collapsed behind a trigger, so the name field does
-    // not exist until it is opened.
-    await authedPage.getByRole('button', { name: 'Start a commitment' }).click();
+    // not exist until it is opened. The trigger's onClick only exists once
+    // React has hydrated — clicking sooner is silent, the form never opens, and
+    // the failure surfaces one line later as "name field not found". Retrying
+    // the click is not an option: it toggles, so a second one would close it.
+    const openCreate = authedPage.getByRole('button', { name: 'Start a commitment' });
+    await waitForHydrated(openCreate);
+    await openCreate.click();
+
     const nameField = authedPage.getByPlaceholder('e.g. Guitar, Running, Spanish');
     await expect(nameField).toBeVisible();
     await nameField.fill(hobby);

--- a/e2e/fixtures/hydration.ts
+++ b/e2e/fixtures/hydration.ts
@@ -1,0 +1,36 @@
+import { expect, type Locator } from '@playwright/test';
+
+/**
+ * Waits until React has hydrated a specific element.
+ *
+ * `toBeVisible()` only proves the server HTML arrived. Interacting before
+ * hydration is silent rather than loud, and it fails in two different ways
+ * depending on the element:
+ *
+ * - **A controlled input** takes the `fill()` into the DOM but not into
+ *   component state. Hydration reverts it, the form compares against its
+ *   unchanged initial prop, skips the write, and still reports success.
+ * - **A button** simply has no handler attached, so the click does nothing and
+ *   whatever it was supposed to reveal never appears.
+ *
+ * Both reproduce only where the route pays a cold `next dev` compile — which is
+ * CI, under two workers, and almost never a warm local run. Both cost a long
+ * time to diagnose because the symptom looks like a product bug.
+ *
+ * Gated on React's own marker rather than a timeout: it attaches
+ * `__reactFiber$…` / `__reactProps$…` keys to each host node as it hydrates,
+ * so this waits for the actual condition instead of guessing a budget.
+ */
+export async function waitForHydrated(target: Locator, timeout = 60_000) {
+  await target.first().waitFor({ state: 'attached', timeout });
+  await expect
+    .poll(
+      async () =>
+        target
+          .first()
+          .evaluate((el) => Object.keys(el).some((k) => k.startsWith('__react')))
+          .catch(() => false),
+      { timeout, message: 'element never hydrated' }
+    )
+    .toBe(true);
+}

--- a/e2e/life-in-weeks.spec.ts
+++ b/e2e/life-in-weeks.spec.ts
@@ -6,6 +6,17 @@ import { expect, test } from '@playwright/test';
  * product does sat behind Google OAuth. These tests hold that door open.
  */
 test.describe('Life in weeks', () => {
+  test('exposes exactly one main landmark', async ({ page }) => {
+    await page.goto('/life-in-weeks');
+    // app/layout.tsx wraps every page in <main id="main">. This page rendered
+    // its own <main> inside that, nesting two landmarks so a screen reader was
+    // offered a choice between them. Caught on production, not by the existing
+    // axe check — that asserts on `main#main`, which a nested unnamed <main>
+    // leaves at a count of one.
+    await expect(page.locator('main')).toHaveCount(1);
+    await expect(page.locator('main#main h1')).toHaveCount(1);
+  });
+
   test('renders and computes for a signed-out visitor', async ({ page }) => {
     await page.goto('/life-in-weeks');
 

--- a/src/app/life-in-weeks/life-in-weeks-client.tsx
+++ b/src/app/life-in-weeks/life-in-weeks-client.tsx
@@ -57,7 +57,11 @@ export function LifeInWeeksClient() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-3xl px-5 py-16 sm:px-8 sm:py-24">
+    // A plain div, not <main>: app/layout.tsx already wraps every page in
+    // <main id="main">, so a second one nests two main landmarks and a screen
+    // reader is offered a choice between them. Thirteen other pages still do
+    // this — see STATUS.md — but this one is the front door.
+    <div className="mx-auto w-full max-w-3xl px-5 py-16 sm:px-8 sm:py-24">
       <h1
         className="font-serif text-4xl font-medium tracking-tight text-foreground sm:text-5xl"
         style={{ textWrap: 'balance', lineHeight: 1.12 }}
@@ -120,7 +124,7 @@ export function LifeInWeeksClient() {
           <Result result={result} />
         </div>
       ) : null}
-    </main>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Duplicate `main` landmark

`app/layout.tsx` already wraps every page in `<main id="main">`, and the new `/life-in-weeks` rendered its own `<main>` inside it — two nested main landmarks, so a screen reader is offered a choice between them. On the page most likely to be someone's first contact with the product.

Caught by driving the **deployed** page, not by a test. The axe check in `content-flywheel.spec.ts` asserts on `main#main`, which a nested unnamed `<main>` leaves at a count of one. The new assertion uses `page.locator('main')`.

Thirteen other route components do the same thing — pre-existing, and a wider sweep than this branch. Filed as next step 1 in `STATUS.md`, along with the note that the existing assertion can't catch it.

## Runbook: deploy build fails while every local build passes

Today's first deploy died in `cf-build.mjs` prerendering `/sitemap.xml`, in a way no local build could reproduce. `deploy.yml` sets no `DATABASE_URL`, so any code path that runs only when a query *fails* is exercised on every deploy and never locally.

Recorded with the repro that does work:

```bash
DATABASE_URL="libsql://nonexistent-host-xyz.turso.io" pnpm build
```

Plus the rule it comes down to: server routes must not import from `'use client'` modules. An unused import is silently fine, which is what lets this class of bug survive review.

## Remaining older-visitor content items

Filed rather than fixed — none are linked from in-product navigation: `/bucket-list-before-30` ("before life narrows"), `/hobbies-for-resume`, the `what-are-significant-hobbies` worked example stopping at "career, now", and the "Life journey" starter template whose last phase ends at age 28.

## Checks

- 367 unit, 105/105 e2e (desktop + landing)
- typecheck, lint, docs:check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)