### PR TITLE
describe every idea, vary the first steps, and facet the hobby catalogue

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -39,6 +39,13 @@ is the bridge between daily practice and life aspirations.
   77 exactly zero, on `/dashboard`, `/daily`, `/trajectory`, `/look-back`,
   `/commitments` and their public profile. See
   [`docs/architecture/decisions.md`](docs/architecture/decisions.md) A10.
+- **The corpus is reachable (2026-07-26):** every "thing you could do" the
+  product owns is now importable data rather than a const inside a page
+  component. 322 experiences at `/experiences`, each with its own page; the
+  suggestion engine reads all of them where it previously had a private
+  52-item pool. 122 hobbies gained twelve cross-cutting facets, so "gentle,
+  cheap, screen-free" is two clicks rather than unanswerable. See
+  [`docs/architecture/decisions.md`](docs/architecture/decisions.md) A11.
 - **Discovery:** the hobby quiz (`/find-your-hobby`) is the single primary
   discovery UX (2026-07-03). The other three surfaces (`/hobbies`, `/explore`,
   `/journeys`) are hidden from homepage/nav/footer; code intact, reachable
@@ -137,16 +144,21 @@ and is genuinely public — that one is consistent.
    `content-flywheel.spec.ts` cannot catch it — it asserts on `main#main`,
    which a nested unnamed `<main>` leaves at a count of one. Sweep the rest and
    tighten that assertion to `page.locator('main')`.
-2. **Content for older visitors, remaining items.** The `/bucket-list-before-30`
+2. **The remaining stranded content.** ~450 list items are still locked inside
+   42 blog posts as prose blocks, and `famous-journeys.ts` (35 lives, 127
+   phases) is in the sitemap but still two hops from any nav entry — its only
+   inbound link is from `/hobbies`, which is itself not in the nav. Surfacing
+   journeys in-product is a quiz-funnel decision, not a code one.
+3. **Content for older visitors, remaining items.** The `/bucket-list-before-30`
    copy ("before life narrows"), `/hobbies-for-resume` framing, the
    `what-are-significant-hobbies` worked example ending at "career, now", and
    the "Life journey" starter template in `src/lib/templates.ts` whose last
    phase ends at age 28. None are linked from in-product navigation.
-3. Apply `drizzle/0003_visibility_and_timezone.sql` to dev and production.
-4. Capture the 7-day PostHog quiz-funnel result, then freeze the winning
+4. Apply `drizzle/0003_visibility_and_timezone.sql` to dev and production.
+5. Capture the 7-day PostHog quiz-funnel result, then freeze the winning
    discovery path and pause feature development.
-5. Review and merge the content-flywheel branch after OpenSpec verification.
-6. **Make the journal an actual bridge.** `journalEntries` has no foreign key
+6. Review and merge the content-flywheel branch after OpenSpec verification.
+7. **Make the journal an actual bridge.** `journalEntries` has no foreign key
    beyond `userId`, so the product's headline claim is copy rather than code.
    Adding an optional hobby/timeline/commitment reference to a journal entry is
    the single highest-leverage change available: it makes the thesis true and
@@ -154,7 +166,7 @@ and is genuinely public — that one is consistent.
    [`docs/product/overview.md`](docs/product/overview.md).
 5. Tighten the first-time user journey to a meaningful public timeline.
 6. Wire habits ↔ commitments (optional explicit link, no auto-link by default).
-7. Decide whether the social layer earns investment. `follows` is a vanity
+8. Decide whether the social layer earns investment. `follows` is a vanity
    counter — no follower list, no feed, and no notification of any kind exists
    in the codebase, so a like, comment, or follow is silently discarded. Either
    ship notifications or stop presenting these as social features.

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -244,3 +244,46 @@ ages 0-120), with regressions pinning the 64- and 71-year-old cases.
   a 71-year-old with 3,734 practice sessions they had not done.
 - The grid's row count is personal, so nothing may assume ~77 rows or a
   4,000-cell array. `LifeGrid` derives its axis label from `cells.length`.
+
+## A11 — A page per experience, and facets over the hobby catalogue
+
+**Decision:** Every one of the 322 experiences has a page at
+`/experiences/<slug>`, browsable and filterable at `/experiences`. Hobbies keep
+their single category and gain twelve cross-cutting facets, filterable on
+`/hobbies`.
+
+**Why:** The corpus audit found roughly 700 distinct possibilities in the repo
+and one source wired to an engine. The rest were consts inside page components
+— unreachable by any code, and reachable by a person only if they happened to
+land on the right SEO page. A product whose thesis is "show people what is
+possible" cannot keep its possibilities in a render tree.
+
+Facets exist because a category answers *what kind of thing is this* and a
+person is asking *would this fit my life*. Those are different questions, and
+the catalogue could only answer the first. `gentle` is the one that matters
+most: it is what lets someone with limited mobility, an injury, or eighty years
+behind them find anything at all.
+
+**Constraints:**
+
+- **Every entry must carry written prose.** Pages were withheld from the 147
+  title-only ideas until each had a description, because a page whose only
+  unique content is its own heading is thin, and thin pages are a *site-wide*
+  signal that would drag down the 122 hobby pages that already work. If a new
+  idea is added without a sentence, it must not get a page.
+- **`firstSteps` is not `generateQuestChain`.** The chain is templated on
+  category alone, so all 75 travel items produced identical body copy with a
+  noun swapped — acceptable inside the app where a user sees one, not across
+  175 indexable pages where it was most of the body. `firstSteps` weaves in the
+  entry's own description, region or horizon, and cross-reference. A test holds
+  bodies above 95% unique across the whole set.
+- **Every hobby takes a position on `gentle` vs `active`.** They are mutually
+  exclusive and one is required — an unlabelled hobby silently vanishes from
+  the filter that matters most. Anything involving kneeling, carrying, or
+  standing for hours is `active`, Gardening included.
+- **Slug collisions resolve to the richer record.** "Run a marathon" is both an
+  idea and a before-50 milestone. Ideas iterate first, so first-writer-wins
+  handed three shared titles to the version with no description and cost each
+  the page it had earned.
+- Destination cross-references point at `FAMOUS_BUCKET_LISTS`, not
+  `famous-journeys`. The two share some names but are separate sets.

--- a/e2e/experiences.spec.ts
+++ b/e2e/experiences.spec.ts
@@ -63,16 +63,18 @@ test.describe('Experiences', () => {
     expect(res.status()).toBe(200);
   });
 
-  /**
-   * Entries with no written description deliberately have no page — 150 pages
-   * whose only unique content is their own heading would be thin, and thin
-   * pages are a site-wide signal.
-   */
-  test('a title-only idea has no page, and neither does a nonsense slug', async ({ page }) => {
-    for (const slug of ['see-the-northern-lights-in-iceland-or-norway', 'not-a-real-thing']) {
-      const res = await page.request.get(`/experiences/${slug}`, { failOnStatusCode: false });
-      expect(res.status(), slug).toBe(404);
-    }
+  test('an idea that used to be title-only now has a page of its own', async ({ page }) => {
+    // These were unpaged until every idea got a written description.
+    await page.goto('/experiences/see-the-northern-lights-in-iceland-or-norway');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Northern Lights');
+    await expect(page.getByRole('heading', { name: 'How you would actually start' })).toBeVisible();
+  });
+
+  test('a nonsense slug still 404s', async ({ page }) => {
+    const res = await page.request.get('/experiences/not-a-real-thing', {
+      failOnStatusCode: false,
+    });
+    expect(res.status()).toBe(404);
   });
 
   test('onward links from a detail page actually go somewhere', async ({ page }) => {

--- a/e2e/hobby-facets.spec.ts
+++ b/e2e/hobby-facets.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Facet browsing on /hobbies. The ten categories answer "what kind of thing is
+ * this"; facets answer "would this fit my life", which is the question someone
+ * with limited mobility or a small budget is actually asking.
+ */
+test.describe('Hobby facets', () => {
+  test('offers facet filters to a signed-out visitor', async ({ page }) => {
+    await page.goto('/hobbies');
+    await expect(page.getByRole('heading', { name: 'Browse by what suits you' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Gentle on the body' })).toBeVisible();
+  });
+
+  test('narrows conjunctively and can be cleared', async ({ page }) => {
+    await page.goto('/hobbies');
+    const status = page.getByText(/hobbies\. Pick a filter|match all/);
+    const total = Number((await status.textContent())?.match(/^(\d+)/)?.[1]);
+    expect(total).toBe(122);
+
+    await page.getByRole('button', { name: 'Gentle on the body' }).click();
+    const afterOne = Number((await status.textContent())?.match(/^(\d+)/)?.[1]);
+    expect(afterOne).toBeLessThan(total);
+
+    await page.getByRole('button', { name: 'Cheap to start' }).click();
+    const afterTwo = Number((await status.textContent())?.match(/^(\d+)/)?.[1]);
+    expect(afterTwo).toBeLessThanOrEqual(afterOne);
+
+    await page.getByRole('button', { name: 'Clear' }).click();
+    await expect(status).toContainText(`${total} hobbies`);
+  });
+
+  /** The reason the facets exist: an older visitor can find something. */
+  test('gentle + cheap + screen-free leaves a usable set', async ({ page }) => {
+    await page.goto('/hobbies');
+    for (const label of ['Gentle on the body', 'Cheap to start', 'No screen']) {
+      await page.getByRole('button', { name: label }).click();
+    }
+    const links = page
+      .locator('section', { hasText: 'Browse by what suits you' })
+      .getByRole('link');
+    expect(await links.count()).toBeGreaterThan(8);
+  });
+
+  test('every result links to a hobby page that exists', async ({ page }) => {
+    await page.goto('/hobbies');
+    await page.getByRole('button', { name: 'Gentle on the body' }).click();
+    const first = page
+      .locator('section', { hasText: 'Browse by what suits you' })
+      .getByRole('link')
+      .first();
+    const href = await first.getAttribute('href');
+    expect(href).toMatch(/^\/hobbies\//);
+    const res = await page.request.get(href as string);
+    expect(res.status()).toBe(200);
+  });
+});

--- a/src/app/experiences/[slug]/page.tsx
+++ b/src/app/experiences/[slug]/page.tsx
@@ -4,12 +4,12 @@ import { notFound } from 'next/navigation';
 
 import { JsonLd } from '~/components/json-ld';
 import {
+  type ExperienceEntry,
   findExperience,
+  firstSteps,
   PAGED_EXPERIENCES,
   relatedExperiences,
-  type ExperienceEntry,
 } from '~/lib/experiences';
-import { generateQuestChain } from '~/lib/quest-chains';
 import { safeDecodeURIComponent } from '~/lib/slug';
 
 /**
@@ -57,14 +57,11 @@ export default async function ExperiencePage({ params }: { params: Promise<{ slu
   const entry = resolve((await params).slug);
   if (!entry) notFound();
 
-  // The chain is the "how would I actually start" section. It is templated per
-  // category, so it supports the page rather than being its substance — the
-  // written description above it is what makes this page worth indexing.
-  const chain = generateQuestChain({
-    bucketItemId: entry.slug,
-    title: entry.title,
-    category: entry.category,
-  });
+  // Not generateQuestChain: that is templated on category alone, so all 75
+  // travel items rendered the same four paragraphs with a noun swapped — most
+  // of the body, identical across the set. These weave in the entry's own
+  // description, region or horizon, and cross-reference.
+  const chain = firstSteps(entry);
   const related = relatedExperiences(entry, 6);
 
   return (
@@ -79,7 +76,7 @@ export default async function ExperiencePage({ params }: { params: Promise<{ slu
             '@type': 'HowToStep',
             position: i + 1,
             name: s.title,
-            text: s.description,
+            text: s.body,
           })),
         }}
       />
@@ -124,13 +121,11 @@ export default async function ExperiencePage({ params }: { params: Promise<{ slu
         <h2 className="font-serif text-2xl text-foreground">How you would actually start</h2>
         <ol className="mt-5 space-y-4">
           {chain.map((step) => (
-            <li key={step.questId} className="border-border border-l-2 pl-4">
+            <li key={step.title} className="border-border border-l-2 pl-4">
               <p className="font-medium text-foreground">
                 {step.emoji} {step.title}
               </p>
-              <p className="mt-1 max-w-[62ch] text-base text-muted-foreground">
-                {step.description}
-              </p>
+              <p className="mt-1 max-w-[62ch] text-base text-muted-foreground">{step.body}</p>
             </li>
           ))}
         </ol>

--- a/src/app/experiences/page.tsx
+++ b/src/app/experiences/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import { EXPERIENCE_CATEGORIES, EXPERIENCE_ENTRIES, PAGED_EXPERIENCES } from '~/lib/experiences';
+import { EXPERIENCE_CATEGORIES, EXPERIENCE_ENTRIES } from '~/lib/experiences';
 import { ExperiencesClient } from './experiences-client';
 
 export const metadata: Metadata = {
@@ -29,8 +29,8 @@ export default function ExperiencesPage() {
       </h1>
       <p className="mt-5 max-w-[62ch] text-lg text-foreground/80" style={{ lineHeight: 1.6 }}>
         {EXPERIENCE_ENTRIES.length} of them, in one place — places to go, milestones worth reaching,
-        and ideas worth stealing. {PAGED_EXPERIENCES.length} have a page of their own with a first
-        step you could take this week.
+        and ideas worth stealing. Each has a page of its own with a first step you could take this
+        week.
       </p>
 
       <ExperiencesClient entries={EXPERIENCE_ENTRIES} categories={EXPERIENCE_CATEGORIES} />

--- a/src/app/hobbies/hobby-facets-client.tsx
+++ b/src/app/hobbies/hobby-facets-client.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+import {
+  ALL_HOBBY_FACETS,
+  facetsForHobby,
+  HOBBY_FACET_LABELS,
+  hobbiesWithFacets,
+  type HobbyFacet,
+} from '~/lib/hobbies';
+
+/**
+ * Browse by fit rather than by department.
+ *
+ * The ten categories answer "what kind of thing is this". They cannot answer
+ * "what could I actually do" — someone who wants something gentle, cheap and
+ * doable alone had no way to ask, and the only route into the catalogue was
+ * picking a category and reading all of it.
+ *
+ * Filters are conjunctive: every selected facet must hold. That makes an empty
+ * result a real possibility, so the empty state names the filter to drop.
+ */
+export function HobbyFacetsClient() {
+  const [selected, setSelected] = useState<HobbyFacet[]>([]);
+
+  const matches = useMemo(() => hobbiesWithFacets(selected), [selected]);
+
+  function toggle(facet: HobbyFacet) {
+    setSelected((prev) =>
+      prev.includes(facet) ? prev.filter((f) => f !== facet) : [...prev, facet]
+    );
+  }
+
+  return (
+    <section className="mb-16">
+      <div className="mb-5 flex items-end justify-between">
+        <h2 className="font-serif text-xl font-semibold text-foreground sm:text-2xl">
+          Browse by what suits you
+        </h2>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {ALL_HOBBY_FACETS.map((facet) => {
+          const active = selected.includes(facet);
+          return (
+            <button
+              key={facet}
+              type="button"
+              onClick={() => toggle(facet)}
+              aria-pressed={active}
+              className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
+                active
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border bg-card text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+              }`}
+            >
+              {HOBBY_FACET_LABELS[facet]}
+            </button>
+          );
+        })}
+        {selected.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setSelected([])}
+            className="rounded-full px-3 py-1.5 text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <p aria-live="polite" className="mt-5 text-sm text-muted-foreground">
+        {selected.length === 0
+          ? `${matches.length} hobbies. Pick a filter to narrow them.`
+          : `${matches.length} match all ${selected.length} filter${selected.length > 1 ? 's' : ''}.`}
+      </p>
+
+      {matches.length === 0 ? (
+        <p className="mt-4 text-base text-muted-foreground">
+          Nothing matches all of those at once. Try dropping the most specific one.
+        </p>
+      ) : (
+        <ul className="mt-4 flex flex-wrap gap-2">
+          {matches.map((hobby) => (
+            <li key={hobby}>
+              <Link
+                href={`/hobbies/${encodeURIComponent(hobby.toLowerCase())}`}
+                prefetch={false}
+                title={facetsForHobby(hobby)
+                  .map((f) => HOBBY_FACET_LABELS[f])
+                  .join(' · ')}
+                className="inline-block rounded-lg border border-border bg-card px-3 py-1.5 text-sm text-foreground transition-colors hover:border-foreground/30"
+              >
+                {hobby}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/app/hobbies/page.tsx
+++ b/src/app/hobbies/page.tsx
@@ -11,6 +11,7 @@ import {
 import { categoryImageSrc, categoryImageSrcSet } from '~/lib/category-images';
 import { HOBBY_CATEGORIES } from '~/lib/hobbies';
 import { cn } from '~/lib/utils';
+import { HobbyFacetsClient } from './hobby-facets-client';
 
 export const metadata = {
   title: 'Hobby Directory — SignificantHobbies',
@@ -46,6 +47,10 @@ export default function HobbiesPage() {
           </p>
         </FadeIn>
       </div>
+
+      {/* Facets first: a category answers "what kind of thing is this", which is
+          only useful once you already know what you want. */}
+      <HobbyFacetsClient />
 
       {/* ─── Browse by category — image cards ─────────────────────────────── */}
       <FadeIn className="mb-16" delay={0.1}>

--- a/src/lib/experiences.test.ts
+++ b/src/lib/experiences.test.ts
@@ -7,6 +7,7 @@ import {
   EXPERIENCE_ENTRIES,
   EXPERIENCES_BY_CATEGORY,
   findExperience,
+  firstSteps,
   MILESTONES,
   PAGED_EXPERIENCES,
   relatedExperiences,
@@ -132,21 +133,28 @@ describe('browsable entries', () => {
   });
 
   /**
-   * Ideas are iterated first and carry no description, so a naive
-   * first-writer-wins dedupe handed three shared titles to the bare version and
-   * cost them a page. The richer record has to win.
+   * Every entry now carries written prose — the 147 title-only ideas were
+   * described, so the whole corpus is pageable rather than the 175 that had
+   * descriptions to begin with.
    */
-  it('keeps the record with prose when two corpora share a title', () => {
-    expect(PAGED_EXPERIENCES).toHaveLength(175);
-    expect(PAGED_EXPERIENCES.length).toBe(MILESTONES.length + DESTINATIONS.length);
+  it('gives every entry a page, because every entry now says something', () => {
+    expect(PAGED_EXPERIENCES).toHaveLength(EXPERIENCE_ENTRIES.length);
+    expect(EXPERIENCE_ENTRIES.filter((e) => !e.description)).toHaveLength(0);
   });
 
-  it('gives a page only to entries that have something to say', () => {
+  it('holds every description to a real sentence, not a restated title', () => {
     for (const e of PAGED_EXPERIENCES) {
-      expect(e.description?.length ?? 0, e.title).toBeGreaterThan(10);
+      const words = (e.description ?? '').trim().split(/\s+/);
+      expect(words.length, e.title).toBeGreaterThanOrEqual(8);
+      expect(words.length, e.title).toBeLessThanOrEqual(30);
+      // A description that merely repeats the title tells the reader nothing.
+      expect(e.description?.toLowerCase(), e.title).not.toBe(e.title.toLowerCase());
     }
-    const unpaged = EXPERIENCE_ENTRIES.filter((e) => !e.description);
-    expect(unpaged.length).toBe(EXPERIENCE_ENTRIES.length - PAGED_EXPERIENCES.length);
+  });
+
+  it('has no two entries sharing a description', () => {
+    const all = PAGED_EXPERIENCES.map((e) => e.description);
+    expect(new Set(all).size).toBe(all.length);
   });
 
   it('resolves a known slug and rejects an unknown one', () => {
@@ -181,5 +189,73 @@ describe('onward links are actually clickable', () => {
 
   it('opens the browse list with something worth reading', () => {
     expect(EXPERIENCE_ENTRIES[0].description).toBeTruthy();
+  });
+
+  it('links every row on the browse list, now that all of them have a page', () => {
+    for (const e of EXPERIENCE_ENTRIES) expect(e.description, e.title).toBeTruthy();
+  });
+});
+
+describe('first steps are not one paragraph reused 175 times', () => {
+  /**
+   * `generateQuestChain` is templated on category alone, so every travel item
+   * produced identical body copy with the title swapped in. On 175 indexable
+   * pages that is most of the body, repeated — the thing that makes a set of
+   * pages read as templated rather than written.
+   */
+  it('reads differently for two destinations in different regions', () => {
+    const europe = PAGED_EXPERIENCES.find((e) => e.region === 'europe');
+    const asia = PAGED_EXPERIENCES.find((e) => e.region === 'asia');
+    if (!europe || !asia) throw new Error('expected a destination in each region');
+    const a = firstSteps(europe)
+      .map((s) => s.body)
+      .join(' ');
+    const b = firstSteps(asia)
+      .map((s) => s.body)
+      .join(' ');
+    expect(a).not.toBe(b);
+  });
+
+  it('reads differently for a milestone and a destination', () => {
+    const milestone = PAGED_EXPERIENCES.find((e) => e.kind === 'milestone');
+    const destination = PAGED_EXPERIENCES.find((e) => e.kind === 'destination');
+    if (!milestone || !destination) throw new Error('expected one of each');
+    expect(firstSteps(milestone).map((s) => s.title)).not.toEqual(
+      firstSteps(destination).map((s) => s.title)
+    );
+  });
+
+  it('weaves each entry own description into its opening step', () => {
+    for (const entry of PAGED_EXPERIENCES.slice(0, 40)) {
+      expect(firstSteps(entry)[0].body, entry.title).toContain(entry.description ?? '');
+    }
+  });
+
+  it('mentions the cross-referenced person where there is one', () => {
+    const withFamous = PAGED_EXPERIENCES.filter((e) => e.famous);
+    expect(withFamous.length).toBeGreaterThan(0);
+    for (const e of withFamous) {
+      const joined = firstSteps(e)
+        .map((s) => `${s.title} ${s.body}`)
+        .join(' ');
+      expect(joined).toContain(e.famous?.name ?? '');
+    }
+  });
+
+  /** The bodies across the whole set should be mostly distinct, not near-clones. */
+  it('produces mostly-unique bodies across every paged entry', () => {
+    const bodies = PAGED_EXPERIENCES.map((e) =>
+      firstSteps(e)
+        .map((s) => s.body)
+        .join(' ')
+    );
+    const unique = new Set(bodies).size;
+    expect(unique / bodies.length).toBeGreaterThan(0.95);
+  });
+
+  it('always gives at least three steps', () => {
+    for (const e of PAGED_EXPERIENCES) {
+      expect(firstSteps(e).length, e.title).toBeGreaterThanOrEqual(3);
+    }
   });
 });

--- a/src/lib/experiences.ts
+++ b/src/lib/experiences.ts
@@ -1494,6 +1494,313 @@ function slugify(value: string): string {
   );
 }
 
+// ─── Idea descriptions ───────────────────────────────────────────────────────
+
+/**
+ * A written line for each of the 147 ideas that had only a title.
+ *
+ * Keyed by slug rather than title, so an idea can be reworded without
+ * orphaning its description. These are what let those entries have a page:
+ * before them, `/experiences/<slug>` would have been a heading and nothing
+ * else, which is a thin page, and thin pages are a site-wide signal.
+ */
+export const IDEA_DESCRIPTIONS: Record<string, string> = {
+  'see-the-northern-lights-in-iceland-or-norway':
+    'Aurora forecasts are a gamble. Clear skies, dark months, and most people waiting several cold nights for one good hour.',
+  'walk-the-camino-de-santiago-800km-across-spain':
+    'Roughly five weeks from the French border, and your feet set the schedule. Beds in albergues cost a few euros.',
+  'safari-in-the-serengeti-at-sunrise':
+    'A cold open-sided jeep and a 5am start, because the cats hunt before the heat arrives and then sleep.',
+  'visit-all-seven-wonders-of-the-world':
+    'Petra, the Colosseum, Chichen Itza, Christ the Redeemer, the Great Wall, Machu Picchu, the Taj. Four continents, years of planning.',
+  'see-the-cherry-blossoms-in-kyoto-japan':
+    'Peak bloom lasts about a week and shifts by a fortnight each year. Book early, then accept the forecast moves.',
+  'drive-route-66-end-to-end-across-america':
+    'Chicago to Santa Monica, about 2,400 miles. Much of it is now frontage road, faded neon, and towns the interstate skipped.',
+  'spend-a-week-in-antarctica':
+    'Two days crossing the Drake Passage before you see land. Expensive, tightly seasonal, and the seasickness is not a rumour.',
+  'swim-in-the-dead-sea':
+    'Ten times saltier than the ocean, so you float without trying. Any cut on your skin will announce itself.',
+  'watch-the-sunrise-from-machu-picchu-peru':
+    'The first bus out of Aguas Calientes leaves before 5am and the queue starts earlier. Cloud often wins anyway.',
+  'take-the-trans-siberian-railway-across-russia':
+    'Seven days, eight time zones, a samovar at the end of each carriage. Bring food, cards, and low expectations of privacy.',
+  'sail-the-greek-islands-for-a-week':
+    'Short hops between anchorages, meltemi winds through August, dinner wherever you tie up. Crewed charters exist if you cannot sail.',
+  'see-the-great-barrier-reef':
+    '1,400 miles of coral, roughly half the cover lost since 1995. Go to the outer reef, not the day-tour pontoons.',
+  'visit-the-taj-mahal-at-dawn':
+    'Gates open at sunrise and the marble runs pink to white within an hour. Closed Fridays for prayer.',
+  'explore-the-amazon-rainforest':
+    'Humidity you wear, and most wildlife heard rather than seen. A local guide is the difference between a green wall and a forest.',
+  'see-the-midnight-sun-in-scandinavia':
+    'Above the Arctic Circle in June the sun never drops. Sleep becomes a decision instead of a response.',
+  'road-trip-across-new-zealand':
+    'Both islands in three weeks is rushing. South Island distances look small on the map and drive twice as long.',
+  'see-the-pyramids-of-giza':
+    "They stand at the edge of Cairo's sprawl, not alone in empty desert. Built before the last mammoths died.",
+  'trek-to-everest-base-camp':
+    'Twelve days up, four down, and 5,364 metres doing most of the work on your lungs. Altitude ignores fitness.',
+  'visit-the-temples-of-angkor-wat-cambodia':
+    'Over 400 square kilometres of ruins. Three days barely covers it, and the crowds thin sharply by mid-afternoon.',
+  'ride-the-orient-express':
+    'The revived Venice Simplon route runs a handful of times a year, costs thousands, and enforces black tie at dinner.',
+  'visit-all-50-us-states':
+    'Alaska and Hawaii are the two that stall people. Most who finish do it in clusters across a decade.',
+  'see-the-tulip-fields-in-the-netherlands':
+    'Six weeks in April and May, then the heads are cut so the bulbs fatten. Rent a bike outside Keukenhof.',
+  'hike-through-patagonia':
+    'Wind that knocks you sideways and four seasons before lunch. The W circuit in Torres del Paine takes five days.',
+  'experience-carnival-in-rio-de-janeiro':
+    'Five days, street blocos from dawn, and Sambadrome parades running until sunrise. Accommodation triples in price a year ahead.',
+  'skydive-from-15-000-feet':
+    'About sixty seconds of freefall before the canopy opens. Tandem needs no training, just a morning and a signature.',
+  'bungee-jump-off-a-bridge':
+    'The stall at the edge is the hard part, not the fall. Operators count down so you stop deliberating.',
+  'climb-a-mountain-over-4-000-metres':
+    'Mont Blanc, Kilimanjaro, and dozens of Colorado peaks qualify. Acclimatise slowly; altitude sickness ignores how strong your legs are.',
+  'surf-a-wave-over-10-feet':
+    'Two-storey faces, long hold-downs, and years of smaller water first. Never paddle out on a big day alone.',
+  'swim-with-humpback-whales':
+    'Tonga and the Dominican Republic license it. They are the length of a bus and decide how close you get.',
+  'run-with-the-bulls-in-pamplona':
+    '825 metres in about three minutes, and people are gored most years. Run sober or watch from a balcony.',
+  'white-water-raft-a-class-v-river':
+    'Continuous rapids where a swim is genuinely dangerous. Guided trips exist, but you still paddle hard on command.',
+  'hike-the-appalachian-trail-end-to-end':
+    '2,190 miles, five to seven months, and roughly one in four who start reach Katahdin.',
+  'dive-the-blue-hole-in-belize':
+    'A sinkhole 124 metres deep with stalactites hanging at forty. Dark, narcotic, and advanced certification is not optional.',
+  'sleep-under-the-stars-in-the-sahara':
+    'No light pollution for hundreds of miles, and near-freezing by 3am. Bring more layers than feels reasonable at noon.',
+  'paraglide-over-the-swiss-alps':
+    'Tandem flights from Interlaken need a short run off the slope and about twenty minutes of your day.',
+  'cage-dive-with-great-white-sharks':
+    'Gansbaai, Guadalupe, or the Farallones. The cage removes the danger and none of the reaction in your chest.',
+  'climb-el-capitan-in-yosemite':
+    '3,000 feet of granite and usually a night sleeping on a portaledge. Years of trad climbing come before it.',
+  'ride-a-motorcycle-across-a-country':
+    'Six hours in the saddle is a long day, and weather arrives without a windscreen. Plan for breakdowns.',
+  'complete-an-ironman-triathlon':
+    '3.8km swim, 180km ride, then a marathon. Six-month plans run about twelve training hours a week.',
+  'hike-the-pacific-crest-trail':
+    '2,650 miles from Mexico to Canada, with snow at both ends of the window. Permits are capped daily.',
+  'go-on-a-polar-expedition':
+    'Hauled sledges, minus forty, and no rescue within hours. Guided crossings cost about what a car costs.',
+  'zipline-through-a-rainforest-canopy':
+    'Thirty metres up on a steel cable, moving fast enough that the canopy blurs. Costa Rica built the template.',
+  'learn-to-free-solo-climb':
+    'No rope means no second mistake. Almost everyone who does it spent a decade roped on the same routes first.',
+  'do-a-polar-bear-plunge':
+    'Cold shock takes your breath in the first ten seconds. Get out before your hands stop obeying you.',
+  'drive-a-racecar-at-full-speed':
+    'Track days put you in a caged car with an instructor beside you. The braking, not the speed, surprises people.',
+  'go-canyoneering':
+    'Abseiling into slot canyons where the only way out is downstream. Check the forecast; flash floods start storms away.',
+  'trek-across-iceland':
+    'The Laugavegur takes four days. The full north-south crossing takes weeks, over unbridged rivers and grey volcanic sand.',
+  'kayak-the-grand-canyon':
+    '277 river miles and roughly three weeks, gated by a private permit lottery most applicants lose for years.',
+  'dog-sled-in-alaska':
+    'Fourteen dogs pulling harder than you expect. Once they settle, the only sound is runners cutting through snow.',
+  'write-and-finish-a-novel':
+    'The finishing is the rare part. Eighty thousand words at five hundred a day is about six months.',
+  'learn-to-play-a-musical-instrument':
+    'The first three months sound bad, and that is the whole test. Twenty minutes daily beats a weekend binge.',
+  'paint-something-you-re-proud-to-hang-on-a-wall':
+    'The first dozen canvases go in a cupboard. Somewhere after that the hand catches up with the eye.',
+  'learn-to-cook-10-world-cuisines-from-scratch':
+    'Start with the pantry, not the recipes. A shelf of fish sauce, gochujang, and dried chillies does most of the work.',
+  'record-a-song-and-release-it':
+    'A laptop, an interface, and a quiet room will do. Distribution to the streaming services costs about twenty pounds a year.',
+  'perform-on-a-stage-in-front-of-a-crowd':
+    'Nerves peak in the wings, not under the lights. Open mics exist so the first time costs nothing.',
+  'learn-a-new-language-to-conversational-fluency':
+    'Roughly 600 hours for a close language, double that for Mandarin or Arabic. Speaking badly early is the shortcut.',
+  'design-and-build-something-with-your-hands':
+    'A shelf, a bike, a bread oven. The measuring is slow and the mistakes stay visible for years.',
+  'take-a-photograph-that-stops-people-in-their-tracks':
+    'Thousands of frames for the one. Light and timing decide it far more than the camera you own.',
+  'write-your-memoir':
+    'Not everything that happened, only what it meant. Most first drafts are far too kind to the writer.',
+  'learn-calligraphy':
+    'Broad nib, ink, and the same letterform a hundred times. The pleasure is the repetition, not the finished card.',
+  'create-a-short-film':
+    'Ten minutes takes a weekend to shoot and a month to cut. Sound is what makes it look expensive.',
+  'take-a-pottery-class-and-make-a-finished-piece':
+    'Centring the clay defeats most beginners for several sessions. Expect a third of your pieces to crack in the kiln.',
+  'learn-watercolour-painting':
+    'Unforgiving. The paper records every hesitation and nothing can be painted over, so the trick is leaving white alone.',
+  'design-and-make-your-own-clothes':
+    'A pattern, a machine, and a great deal of unpicking. Fit on your own body is the reward.',
+  'build-a-piece-of-furniture-from-scratch':
+    'A stool before a table. Wood moves with the seasons, which is why joints matter more than screws.',
+  'start-a-podcast':
+    'Most die at episode seven. One cheap dynamic microphone and a consistent day of the week beat any gear list.',
+  'perform-stand-up-comedy':
+    'Five minutes takes months to write and dozens of open mics to sand down. Silence teaches faster than laughter.',
+  'choreograph-and-perform-a-dance':
+    'Counting eights until the shape holds, then discovering what the body does differently once someone is watching.',
+  'compose-an-original-piece-of-music':
+    "Eight bars that are genuinely yours is harder than an hour of other people's. The notation software is free.",
+  'illustrate-a-children-s-book':
+    'Thirty-two pages, the same character recognisable in every spread, and the pictures carrying what the words leave out.',
+  'throw-a-kiln-fired-ceramic-pot':
+    'Wedge, centre, pull, dry slowly, glaze, fire. Six stages, and any one of them can take the piece from you.',
+  'learn-to-draw-portraits':
+    'The eyes sit halfway down the skull, which nobody believes until they measure. Start with faces you already know.',
+  'write-and-perform-spoken-word-poetry':
+    'Written for the ear, so it only exists out loud. Most pieces change shape in the final rehearsal.',
+  'publish-an-article-in-a-magazine':
+    'Pitch before you write. Three paragraphs, a clear angle, and a reason it has to be you.',
+  'learn-to-fly-a-plane':
+    'Hands on the yoke within ten minutes of the first lesson. Landing is the part that takes forty attempts.',
+  'start-and-grow-a-business':
+    'Revenue before polish. Most of year one is finding out who actually pays, and what they think they bought.',
+  'earn-a-black-belt-in-a-martial-art':
+    'Four to six years of turning up twice a week. The belt marks the end of the beginning.',
+  'become-fluent-in-a-second-language':
+    'Fluent means arguing, joking, and handling a phone call. That sits several years past ordering dinner confidently.',
+  'read-52-books-in-a-year':
+    'About forty pages a day. Abandoning books that are not working is part of the method, not a failure.',
+  'become-completely-debt-free':
+    'The final payment feels smaller than expected. The change is in what the monthly numbers stop deciding for you.',
+  'meditate-every-day-for-365-days':
+    'Ten minutes counts. What matters is what happens after month one, when it has become reliably boring.',
+  'learn-to-code-and-ship-an-app':
+    "Shipping is a separate skill from writing code: deploys, sign-ups, and someone else's browser breaking it quietly.",
+  'climb-the-corporate-ladder-to-a-role-you-dreamed-of':
+    'Visible work over years, plus a few people willing to say your name in rooms you are not in.',
+  'compete-in-a-national-championship':
+    'Qualifying standards are published years ahead. Most of the field trains around a full-time job to meet them.',
+  'earn-a-postgraduate-degree':
+    'One to five years, often alongside work, ending in a thesis few people read and one mind permanently rewired.',
+  'break-a-personal-athletic-record':
+    'Progressive overload and patience. Records usually fall in sessions that felt completely unremarkable at the time.',
+  'master-a-complex-card-trick':
+    'Sleight of hand only looks casual after a thousand repetitions in front of a mirror. The patter takes as long.',
+  'memorise-a-long-poem-or-speech':
+    'The method of loci, or brute repetition. Either takes a few weeks and then stays available for decades.',
+  'build-an-investment-portfolio':
+    'Boring wins: low fees, broad index funds, and not touching anything the month the numbers drop.',
+  'complete-a-tough-mudder':
+    'Ten miles, twenty-odd obstacles, and mud you find days later. Strangers pull each other over the walls.',
+  'do-100-push-ups-in-a-row':
+    'Small sets scattered through the day beat one hard session. Most plans get there in a couple of months.',
+  'become-a-certified-scuba-diver':
+    'Open Water takes four days, and about twenty dives before you stop thinking about your own breathing.',
+  'get-a-pilot-s-licence':
+    'Forty logged hours minimum, a written exam, a medical, and a check ride. Budget well past the advertised figure.',
+  'compete-in-an-obstacle-course-race':
+    'Grip strength decides more of these than running does. Hang from a bar twice a week for a season.',
+  'solve-a-rubik-s-cube-in-under-a-minute':
+    'Learn the beginner method, then drill it. Sub-minute takes a few weeks and no unusual talent.',
+  'complete-a-100-mile-ultramarathon':
+    'Twenty-four to thirty-six hours, much of it walking, with a crew handing you food you no longer want.',
+  'qualify-for-the-boston-marathon':
+    'A certified course and a time that tightens each year. The real cutoff has beaten the published standard since 2011.',
+  'volunteer-abroad-for-at-least-a-month':
+    'Pick an organisation that would exist without you. The skills they lack beat the enthusiasm they already have.',
+  'reconnect-with-someone-you-ve-lost-touch-with':
+    'The awkward first message is shorter than you think. Most people are glad, and assumed you had moved on.',
+  'host-a-dinner-party-for-20-people':
+    'Cook one thing that scales and buy the rest. A host still in the kitchen at nine has planned wrong.',
+  'make-a-close-friend-in-another-country':
+    'It takes more than a good week together. It takes the messages afterwards, across time zones, for years.',
+  'mentor-someone-just-starting-out-in-your-field':
+    'An hour a month and honest answers. What they need is the map, not the encouragement.',
+  'attend-a-world-class-sporting-event-live':
+    "Television flattens the speed. Sit high enough to read the shape of the play rather than the players' faces.",
+  'tell-the-most-important-people-in-your-life-why-they-matter':
+    'Specific beats general. Name the thing they did and roughly when, not their qualities in the abstract.',
+  'throw-a-surprise-party-that-genuinely-surprises-someone':
+    'One leak ends it. Fewer people in on it, and a cover story boring enough to sound like a Tuesday.',
+  'join-a-community-choir-or-theatre-group':
+    'Most of them do not audition. You will be the worst there for a season, alongside people who once were.',
+  'take-a-road-trip-with-your-best-friends':
+    'The long silences in the car are the point. Book less than feels safe and leave afternoons unplanned.',
+  'write-heartfelt-letters-to-10-people-who-changed-your-life':
+    'Handwritten, posted, no reply expected. Several will keep it in a drawer for the rest of their lives.',
+  'spend-a-week-with-your-grandparents-or-elders':
+    'Bring a recorder and ask about the years before you existed. Nobody regrets the tape; plenty regret not making it.',
+  'host-a-family-reunion':
+    'Somebody has to send the first message to forty people. The logistics are dull and the room is not.',
+  'learn-someone-s-language-to-have-a-conversation-with-them':
+    "Enough to sit at their mother's table and follow the joke. Fluency is optional; the effort is legible.",
+  'attend-a-multi-day-music-festival':
+    'Three days of standing, poor sleep, and one set you will still describe in twenty years. Bring earplugs.',
+  'do-a-group-charity-challenge-with-friends':
+    'Training together is most of it. The fundraising page gets awkward around the third ask, and works anyway.',
+  'create-a-family-cookbook-with-old-recipes':
+    'The measurements will be missing. Cook alongside whoever wrote them and record what their hands actually do.',
+  'organise-a-neighbourhood-event':
+    'A street closure form, twenty flyers, and borrowed trestle tables. Most neighbours say yes once somebody else has started.',
+  'get-married-or-celebrate-a-long-term-partnership':
+    'The vows outlast the catering. Smaller rooms tend to hold more of what people actually came for.',
+  'spend-a-month-living-with-a-foreign-family':
+    'Meals are where the language happens. A month is long enough to stop being treated as a guest.',
+  'teach-a-skill-you-re-good-at-to-a-group-of-strangers':
+    'You will find the holes in your own understanding within ten minutes. Prepare less and demonstrate more.',
+  'have-a-meaningful-conversation-with-a-complete-stranger-every-week-for-a-year':
+    'Fifty-two openings, and the first question is the whole skill. Ask what they are working on, then stop talking.',
+  'co-write-something-with-a-friend':
+    'Two hands on one document tests a friendship early. Agree who holds the final cut before the first draft.',
+  'show-up-for-someone-in-a-crisis-without-being-asked':
+    'Do not ask what they need. Bring food, run the laundry, sit there. An offer is a task; presence is not.',
+  'celebrate-someone-else-s-milestone-as-if-it-were-your-own':
+    'Turn up, take the photographs, make the toast. The absence of envy is the whole thing, and it is practised.',
+  'plant-1-000-trees':
+    'Native species, right site, and somebody watering through three summers. Survival rate matters far more than the number planted.',
+  'fund-a-child-s-education-for-a-year':
+    'Fees, uniform, and books run to a few hundred pounds a year in much of the world. Ask the school directly.',
+  'build-something-that-outlasts-you':
+    'A trust, a trail, an institution with its own funding. It only counts once it runs without you.',
+  'raise-money-for-a-cause-you-deeply-believe-in':
+    'The first ten donations come from people who would have given you the money anyway. The next hundred need a reason.',
+  'donate-anonymously-and-tell-no-one':
+    'No receipt, no thank-you note, no post about it. Find out what the impulse is worth when nobody is counting.',
+  'start-a-scholarship-fund':
+    'An endowment needs capital. An annual award needs only a cheque and a school willing to administer it.',
+  'build-a-school-or-library-in-an-underserved-community':
+    'The building is the easy part. Teachers, salaries, and maintenance are what quietly fail in year three.',
+  'volunteer-at-a-hospital-for-a-year':
+    'Mostly directions, tea, and sitting with patients whose families cannot get there. Weekly shifts, and nothing about it photographs well.',
+  'teach-english-in-a-developing-country':
+    'A CELTA takes a month and separates you from volunteers who leave a class worse than they found it.',
+  'adopt-or-foster-a-child':
+    'Approval runs six months to two years of assessment. Teenagers are where the shortage of placements actually sits.',
+  'donate-a-kidney-or-be-a-living-donor':
+    'One night in hospital, six weeks off work, and a stranger comes off dialysis. Long-term donor risk stays near baseline.',
+  'leave-a-legacy-gift-to-a-charity-in-your-will':
+    'One clause and a registered charity number. Costs nothing now and moves more than most people give while living.',
+  'start-a-foundation':
+    'Trustees, registration, and annual accounts. Below a certain size the reporting burden outweighs everything it manages to give away.',
+  'clean-up-a-beach-or-river-in-your-community':
+    'Two hours, gloves, and a shared bin bag. Log what you find; the data travels further than the litter.',
+  'create-a-free-resource-that-helps-thousands-of-people':
+    'One good guide, kept current for years. The maintenance is what separates it from thousands of abandoned ones.',
+  'advocate-for-a-policy-change-you-believe-in':
+    'Committee submissions, one councillor at a time, and years of no. Then it passes and everyone calls it obvious.',
+  'feed-a-hundred-families':
+    'A food bank moves more per pound than a collection tin. Ask what they are short of before buying anything.',
+  'sponsor-a-refugee-family':
+    'Housing, a bank account, school places, and a year of phone calls. Community sponsorship schemes exist in most countries.',
+  'run-for-local-office':
+    'Signatures, a deposit, and hundreds of doors. Local seats turn on a few hundred votes, and often nobody else stands.',
+  'start-a-community-garden':
+    'Permission from a landowner, a water supply, and six people who still turn up in November. Plots fill faster than volunteers.',
+  'write-a-book-that-changes-someone-s-life':
+    'You will never know which reader it was. Write the thing you needed and could not find.',
+  'give-blood-50-times-in-your-life':
+    'Every twelve weeks, an hour each time. Fifty donations is roughly fifteen years of quietly turning up.',
+  'reduce-your-carbon-footprint-to-near-zero':
+    'Flights, home heating, and beef account for most of it. The last tonne costs far more effort than the first five.',
+  'build-homes-with-habitat-for-humanity':
+    'No trade skills required on site. Framing, painting, and the family who will live there working the same shift.',
+  'leave-a-place-cleaner-and-more-hopeful-than-you-found-it':
+    'The measure is what is still standing a year after you left, and whether anyone there mentions your name.',
+};
+
 /**
  * Every entry across all three corpora, deduplicated and slugged.
  *
@@ -1518,7 +1825,15 @@ export const EXPERIENCE_ENTRIES: ExperienceEntry[] = (() => {
   for (const category of EXPERIENCE_CATEGORIES) {
     const group = EXPERIENCES_BY_CATEGORY[category];
     for (const title of group.ideas) {
-      add({ slug: slugify(title), title, emoji: group.emoji, category, kind: 'idea' });
+      const slug = slugify(title);
+      add({
+        slug,
+        title,
+        description: IDEA_DESCRIPTIONS[slug],
+        emoji: group.emoji,
+        category,
+        kind: 'idea',
+      });
     }
   }
   for (const m of MILESTONES) {
@@ -1585,4 +1900,92 @@ export function relatedExperiences(entry: ExperienceEntry, limit = 6): Experienc
     0,
     limit
   );
+}
+
+// ─── First steps ─────────────────────────────────────────────────────────────
+
+export type FirstStep = { title: string; body: string; emoji: string };
+
+/** Region-specific practicality, so travel steps are not one paragraph reused 75 times. */
+const REGION_NOTE: Record<DestinationRegion, string> = {
+  europe: 'Shoulder season — May or September — is usually cheaper and less crowded than summer.',
+  asia: 'Monsoon and dry season matter more than temperature here; check which months you want.',
+  americas:
+    'Distances are larger than they look on a map. Budget travel days, not just arrival dates.',
+  'africa-middle-east':
+    'Wildlife and heat both run on a calendar. The right month changes the trip entirely.',
+  'oceania-antarctica':
+    'Seasons are inverted, and the far south has a narrow window. Book further ahead than feels sensible.',
+};
+
+const HORIZON_NOTE: Record<MilestoneHorizon, string> = {
+  'before-30': 'No deadline is real here. The list is a prompt, not a schedule.',
+  'before-50': 'Most people who do this start before they feel ready for it.',
+};
+
+/**
+ * The "how would I actually start" steps shown on an experience page.
+ *
+ * Deliberately not `generateQuestChain`. That one is templated purely on
+ * category and title, so all 75 travel items produced the same four
+ * paragraphs with a noun swapped — fine inside the app where a user sees one
+ * of them, bad on 175 indexable pages where it is most of the body.
+ *
+ * These weave the entry's own data in: its description, its region or horizon,
+ * and the person who did it. Two destinations in different regions no longer
+ * read alike, and a milestone never reads like a destination.
+ */
+export function firstSteps(entry: ExperienceEntry): FirstStep[] {
+  const steps: FirstStep[] = [];
+
+  // The description is quoted rather than restated. It appears as the lead
+  // paragraph directly above, and an unattributed repeat a few hundred pixels
+  // later reads like a mistake; framing it as the claim being tested makes the
+  // repetition deliberate and gives the step something to argue with.
+  steps.push({
+    emoji: '🔍',
+    title: 'Check whether the promise holds',
+    body: entry.description
+      ? `“${entry.description}” That is the pitch. Spend an hour on first-hand accounts rather than listicles — what it costs, how long it really takes, and what people wish they had known.`
+      : 'Spend an hour on first-hand accounts rather than listicles — what it costs, how long it really takes, and what people wish they had known.',
+  });
+
+  if (entry.kind === 'destination' && entry.region) {
+    steps.push({
+      emoji: '🗓️',
+      title: 'Work out when to go',
+      body: REGION_NOTE[entry.region],
+    });
+  } else if (entry.kind === 'milestone' && entry.horizon) {
+    steps.push({
+      emoji: '🗓️',
+      title: 'Decide what "started" would look like',
+      body: `${HORIZON_NOTE[entry.horizon]} Name the smallest thing that would count as having begun, and do that one.`,
+    });
+  }
+
+  steps.push({
+    emoji: '🪜',
+    title: 'Find the small version first',
+    body:
+      entry.category === 'travel'
+        ? 'Somewhere nearer will tell you whether you actually like this kind of trip, for a fraction of the cost.'
+        : 'There is almost always a one-afternoon version. Do that before committing money or telling anyone.',
+  });
+
+  if (entry.famous) {
+    steps.push({
+      emoji: '👤',
+      title: `Read how ${entry.famous.name} approached it`,
+      body: `${entry.famous.name} ${entry.famous.note}. Other people's accounts are the cheapest research there is.`,
+    });
+  }
+
+  steps.push({
+    emoji: '📌',
+    title: 'Put it somewhere you will see it',
+    body: 'An intention you have not written down is a mood. A list you revisit is a decision you keep making.',
+  });
+
+  return steps;
 }

--- a/src/lib/hobbies.test.ts
+++ b/src/lib/hobbies.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { HOBBY_CATEGORIES, getCategoryForHobby, isStrenuous, pickAcrossEffort } from './hobbies';
+import {
+  ALL_HOBBIES,
+  ALL_HOBBY_FACETS,
+  facetsForHobby,
+  getCategoryForHobby,
+  HOBBY_CATEGORIES,
+  HOBBY_FACETS,
+  hobbiesWithFacets,
+  isStrenuous,
+  pickAcrossEffort,
+} from './hobbies';
 
 const physical = HOBBY_CATEGORIES.find((c) => c.name === 'Physical');
 
@@ -66,5 +76,64 @@ describe('catalog coverage for older visitors', () => {
   it('has no duplicate hobbies across categories', () => {
     const all = HOBBY_CATEGORIES.flatMap((c) => c.hobbies).map((h) => h.toLowerCase());
     expect(new Set(all).size).toBe(all.length);
+  });
+});
+
+describe('hobby facets', () => {
+  it('covers every hobby in the catalogue, and nothing else', () => {
+    const names = new Set(ALL_HOBBIES);
+    const keys = Object.keys(HOBBY_FACETS);
+    expect(keys).toHaveLength(names.size);
+    for (const k of keys) expect(names.has(k), `${k} is not in the catalogue`).toBe(true);
+    for (const n of names) expect(HOBBY_FACETS[n], `${n} has no facets`).toBeDefined();
+  });
+
+  it('uses only known facet ids, 3 to 6 per hobby', () => {
+    const valid = new Set(ALL_HOBBY_FACETS);
+    for (const [hobby, facets] of Object.entries(HOBBY_FACETS)) {
+      expect(facets.length, hobby).toBeGreaterThanOrEqual(3);
+      expect(facets.length, hobby).toBeLessThanOrEqual(6);
+      expect(new Set(facets).size, `${hobby} has a duplicate facet`).toBe(facets.length);
+      for (const f of facets) expect(valid.has(f), `${hobby}: ${f}`).toBe(true);
+    }
+  });
+
+  /**
+   * `gentle` is the facet that lets someone with limited mobility find
+   * anything at all, so every hobby has to take a position — an unlabelled
+   * hobby silently disappears from the one filter that matters most.
+   */
+  it('commits every hobby to exactly one of gentle or active', () => {
+    for (const [hobby, facets] of Object.entries(HOBBY_FACETS)) {
+      const gentle = facets.includes('gentle');
+      const active = facets.includes('active');
+      expect(gentle !== active, `${hobby} is ${gentle ? 'both' : 'neither'}`).toBe(true);
+    }
+  });
+
+  it('keeps the gentle set genuinely gentle', () => {
+    for (const hobby of ['Walking', 'Tai chi', 'Reading', 'Crosswords', 'Bridge']) {
+      expect(facetsForHobby(hobby), hobby).toContain('gentle');
+    }
+    // Kneeling, carrying, standing for hours — none of these are gentle.
+    for (const hobby of ['Gardening', 'Climbing', 'Running', 'Blacksmithing']) {
+      expect(facetsForHobby(hobby), hobby).toContain('active');
+    }
+  });
+
+  it('filters conjunctively, and an empty filter matches everything', () => {
+    expect(hobbiesWithFacets([])).toHaveLength(ALL_HOBBIES.length);
+
+    const gentleSolo = hobbiesWithFacets(['gentle', 'solo']);
+    expect(gentleSolo.length).toBeGreaterThan(10);
+    expect(gentleSolo.length).toBeLessThan(ALL_HOBBIES.length);
+    for (const h of gentleSolo) {
+      expect(facetsForHobby(h)).toEqual(expect.arrayContaining(['gentle', 'solo']));
+    }
+  });
+
+  it('leaves a usable set for someone who wants gentle, cheap and screen-free', () => {
+    const found = hobbiesWithFacets(['gentle', 'low-cost', 'screen-free']);
+    expect(found.length).toBeGreaterThan(8);
   });
 });

--- a/src/lib/hobbies.ts
+++ b/src/lib/hobbies.ts
@@ -285,3 +285,194 @@ export function getSuggestedHobbies(existingHobbies: string[], limit = 6): strin
   // Deduplicate and limit
   return [...new Set(suggestions)].slice(0, limit);
 }
+
+// ─── Facets ──────────────────────────────────────────────────────────────────
+
+/**
+ * Cross-cutting tags, orthogonal to the ten categories.
+ *
+ * A category answers "what kind of thing is this"; a facet answers "would this
+ * fit my life". Those are different questions, and the catalogue could only
+ * answer the first — so someone who wanted something gentle, cheap and doable
+ * alone had no way to ask.
+ *
+ * `gentle` carries the most weight. It is the one that lets a person with
+ * limited mobility, an injury, or eighty years behind them find something, so
+ * it is assigned strictly: anything involving kneeling, carrying, or standing
+ * for hours is `active`, Gardening included.
+ */
+export type HobbyFacet =
+  | 'solo'
+  | 'group'
+  | 'indoor'
+  | 'outdoor'
+  | 'travel'
+  | 'low-cost'
+  | 'gentle'
+  | 'active'
+  | 'makes-something'
+  | 'learn-a-skill'
+  | 'quiet'
+  | 'screen-free';
+
+export const HOBBY_FACET_LABELS: Record<HobbyFacet, string> = {
+  solo: 'On your own',
+  group: 'With others',
+  indoor: 'Indoors',
+  outdoor: 'Outdoors',
+  travel: 'Involves going somewhere',
+  'low-cost': 'Cheap to start',
+  gentle: 'Gentle on the body',
+  active: 'Physically active',
+  'makes-something': 'You end up with something',
+  'learn-a-skill': 'Gets better with practice',
+  quiet: 'Quiet',
+  'screen-free': 'No screen',
+};
+
+export const HOBBY_FACETS: Record<string, HobbyFacet[]> = {
+  Drawing: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  Painting: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  Photography: ['solo', 'indoor', 'outdoor', 'gentle', 'makes-something', 'learn-a-skill'],
+  Writing: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'quiet'],
+  Sculpting: ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill', 'screen-free'],
+  Ceramics: ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill', 'screen-free'],
+  Knitting: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'quiet'],
+  Crochet: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'quiet'],
+  Quilting: ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill', 'screen-free'],
+  Embroidery: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'quiet'],
+  Sewing: ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill', 'screen-free'],
+  Origami: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'quiet'],
+  Calligraphy: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  'Graphic design': ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill'],
+  'Music production': ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill'],
+  Songwriting: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  Poetry: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'quiet'],
+  Filmmaking: ['group', 'indoor', 'outdoor', 'gentle', 'makes-something', 'learn-a-skill'],
+  Cosplay: ['solo', 'group', 'indoor', 'gentle', 'makes-something', 'learn-a-skill'],
+  Guitar: ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Piano: ['solo', 'indoor', 'gentle', 'learn-a-skill', 'screen-free'],
+  Drums: ['solo', 'indoor', 'active', 'learn-a-skill', 'screen-free'],
+  Violin: ['solo', 'group', 'indoor', 'gentle', 'learn-a-skill', 'screen-free'],
+  Bass: ['solo', 'group', 'indoor', 'gentle', 'learn-a-skill', 'screen-free'],
+  Singing: ['solo', 'group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill'],
+  DJing: ['solo', 'group', 'indoor', 'gentle', 'learn-a-skill'],
+  Ukulele: ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Saxophone: ['solo', 'group', 'indoor', 'gentle', 'learn-a-skill', 'screen-free'],
+  Flute: ['solo', 'group', 'indoor', 'gentle', 'learn-a-skill', 'screen-free'],
+  'Music theory': ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'quiet'],
+  Walking: ['solo', 'group', 'outdoor', 'low-cost', 'gentle', 'screen-free'],
+  Running: ['solo', 'group', 'outdoor', 'low-cost', 'active', 'screen-free'],
+  Cycling: ['solo', 'group', 'outdoor', 'active', 'learn-a-skill', 'screen-free'],
+  Swimming: ['solo', 'indoor', 'outdoor', 'low-cost', 'active', 'screen-free'],
+  Hiking: ['solo', 'group', 'outdoor', 'low-cost', 'active', 'screen-free'],
+  Climbing: ['solo', 'group', 'indoor', 'outdoor', 'active', 'learn-a-skill'],
+  Yoga: ['solo', 'group', 'indoor', 'outdoor', 'low-cost', 'gentle'],
+  'Tai chi': ['solo', 'group', 'indoor', 'outdoor', 'low-cost', 'gentle'],
+  Pilates: ['solo', 'group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill'],
+  Gym: ['solo', 'indoor', 'active', 'learn-a-skill', 'screen-free'],
+  'Martial arts': ['group', 'indoor', 'active', 'learn-a-skill', 'screen-free'],
+  Dance: ['solo', 'group', 'indoor', 'active', 'learn-a-skill', 'screen-free'],
+  Golf: ['solo', 'group', 'outdoor', 'active', 'learn-a-skill', 'screen-free'],
+  Bowling: ['solo', 'group', 'indoor', 'low-cost', 'gentle', 'screen-free'],
+  'Lawn bowls': ['group', 'outdoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Basketball: ['group', 'indoor', 'outdoor', 'low-cost', 'active', 'screen-free'],
+  Football: ['group', 'outdoor', 'low-cost', 'active', 'screen-free'],
+  Tennis: ['group', 'outdoor', 'active', 'learn-a-skill', 'screen-free'],
+  'Table tennis': ['group', 'indoor', 'low-cost', 'active', 'learn-a-skill', 'screen-free'],
+  Skiing: ['group', 'outdoor', 'travel', 'active', 'learn-a-skill', 'screen-free'],
+  Skateboarding: ['solo', 'outdoor', 'active', 'learn-a-skill', 'screen-free'],
+  Surfing: ['solo', 'outdoor', 'travel', 'active', 'learn-a-skill', 'screen-free'],
+  Rowing: ['solo', 'group', 'outdoor', 'active', 'learn-a-skill', 'screen-free'],
+  Badminton: ['group', 'indoor', 'low-cost', 'active', 'learn-a-skill', 'screen-free'],
+  'Scuba diving': ['group', 'outdoor', 'travel', 'active', 'learn-a-skill', 'screen-free'],
+  Fencing: ['group', 'indoor', 'active', 'learn-a-skill', 'screen-free'],
+  Pickleball: ['group', 'indoor', 'outdoor', 'low-cost', 'active', 'screen-free'],
+  Reading: ['solo', 'indoor', 'low-cost', 'gentle', 'quiet', 'screen-free'],
+  Crosswords: ['solo', 'indoor', 'low-cost', 'gentle', 'quiet', 'screen-free'],
+  Chess: ['solo', 'group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill'],
+  Bridge: ['group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Genealogy: ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'quiet'],
+  Coding: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  'Language learning': ['solo', 'group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill'],
+  Puzzles: ['solo', 'indoor', 'low-cost', 'gentle', 'quiet', 'screen-free'],
+  Sudoku: ['solo', 'indoor', 'low-cost', 'gentle', 'quiet', 'screen-free'],
+  Philosophy: ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'quiet'],
+  History: ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'quiet'],
+  Astronomy: ['solo', 'outdoor', 'gentle', 'learn-a-skill', 'quiet', 'screen-free'],
+  Mathematics: ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'quiet'],
+  Science: ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'quiet'],
+  'Video games': ['solo', 'group', 'indoor', 'gentle', 'learn-a-skill'],
+  'Board games': ['solo', 'group', 'indoor', 'gentle', 'learn-a-skill', 'screen-free'],
+  'Tabletop RPGs': ['group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Speedrunning: ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill'],
+  Esports: ['group', 'indoor', 'gentle', 'learn-a-skill'],
+  'Card games': ['solo', 'group', 'indoor', 'low-cost', 'gentle', 'screen-free'],
+  'Dungeon Master': ['group', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  Gardening: ['solo', 'outdoor', 'low-cost', 'active', 'makes-something', 'learn-a-skill'],
+  'Bird watching': ['solo', 'group', 'outdoor', 'low-cost', 'gentle', 'quiet'],
+  Camping: ['solo', 'group', 'outdoor', 'travel', 'active', 'screen-free'],
+  Fishing: ['solo', 'outdoor', 'travel', 'gentle', 'quiet', 'screen-free'],
+  Foraging: ['solo', 'outdoor', 'travel', 'low-cost', 'active', 'screen-free'],
+  Stargazing: ['solo', 'outdoor', 'travel', 'low-cost', 'gentle', 'quiet'],
+  'Rock collecting': ['solo', 'outdoor', 'low-cost', 'active', 'learn-a-skill', 'screen-free'],
+  Beekeeping: ['solo', 'outdoor', 'active', 'makes-something', 'learn-a-skill', 'screen-free'],
+  Geocaching: ['solo', 'group', 'outdoor', 'travel', 'low-cost', 'active'],
+  'Mushroom hunting': ['solo', 'outdoor', 'travel', 'low-cost', 'active', 'learn-a-skill'],
+  Cooking: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  Baking: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  'Coffee brewing': ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill', 'screen-free'],
+  'Wine tasting': ['group', 'indoor', 'gentle', 'learn-a-skill', 'screen-free'],
+  'Cocktail making': ['solo', 'group', 'indoor', 'gentle', 'makes-something', 'learn-a-skill'],
+  Fermentation: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  BBQ: ['group', 'outdoor', 'active', 'makes-something', 'learn-a-skill', 'screen-free'],
+  'Food photography': ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  'Vinyl records': ['solo', 'indoor', 'gentle', 'quiet', 'screen-free'],
+  Books: ['solo', 'indoor', 'low-cost', 'gentle', 'quiet', 'screen-free'],
+  Stamps: ['solo', 'indoor', 'low-cost', 'gentle', 'quiet', 'screen-free'],
+  Coins: ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Art: ['solo', 'indoor', 'gentle', 'quiet', 'learn-a-skill'],
+  Sneakers: ['solo', 'group', 'indoor', 'gentle', 'learn-a-skill'],
+  'Vintage clothing': ['solo', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Watches: ['solo', 'indoor', 'gentle', 'learn-a-skill', 'quiet'],
+  Woodworking: ['solo', 'indoor', 'active', 'makes-something', 'learn-a-skill', 'screen-free'],
+  '3D printing': ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill'],
+  Electronics: ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  Leatherworking: ['solo', 'indoor', 'gentle', 'makes-something', 'learn-a-skill', 'screen-free'],
+  Blacksmithing: ['solo', 'indoor', 'active', 'makes-something', 'learn-a-skill', 'screen-free'],
+  'Candle making': ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'screen-free'],
+  'Soap making': ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  'Jewelry making': ['solo', 'indoor', 'low-cost', 'gentle', 'makes-something', 'learn-a-skill'],
+  'LEGO building': ['solo', 'indoor', 'gentle', 'makes-something', 'quiet', 'screen-free'],
+  Volunteering: ['group', 'indoor', 'outdoor', 'low-cost', 'gentle', 'screen-free'],
+  'Hosting dinners': [
+    'group',
+    'indoor',
+    'gentle',
+    'makes-something',
+    'learn-a-skill',
+    'screen-free',
+  ],
+  'Book club': ['group', 'indoor', 'low-cost', 'gentle', 'screen-free'],
+  Choir: ['group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Mahjong: ['group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  'Improv comedy': ['group', 'indoor', 'active', 'learn-a-skill', 'screen-free'],
+  Theater: ['group', 'indoor', 'active', 'learn-a-skill', 'screen-free'],
+  'Debate club': ['group', 'indoor', 'low-cost', 'gentle', 'learn-a-skill', 'screen-free'],
+  Travel: ['solo', 'group', 'outdoor', 'travel', 'active', 'learn-a-skill'],
+};
+
+export const ALL_HOBBY_FACETS = Object.keys(HOBBY_FACET_LABELS) as HobbyFacet[];
+
+export function facetsForHobby(hobby: string): HobbyFacet[] {
+  return HOBBY_FACETS[hobby] ?? [];
+}
+
+/** Hobbies carrying every one of the given facets. An empty filter matches all. */
+export function hobbiesWithFacets(facets: HobbyFacet[]): string[] {
+  if (facets.length === 0) return ALL_HOBBIES;
+  return ALL_HOBBIES.filter((h) => {
+    const owned = HOBBY_FACETS[h];
+    return owned ? facets.every((f) => owned.includes(f)) : false;
+  });
+}


### PR DESCRIPTION
The three things left open on the experiences work.

## Every entry now has a page — 322, up from 175

The 147 title-only ideas were held back because a page whose only unique content is its own heading is thin, and thin pages are a **site-wide** signal. Each now has a written line, keyed by slug so an idea can be reworded without orphaning its description.

> *"Small sets scattered through the day beat one hard session. Most plans get there in a couple of months."* — Do 100 push-ups in a row
>
> *"Not everything that happened, only what it meant. Most first drafts are far too kind to the writer."* — Write your memoir

Same rules as the existing prose: 12–25 words, concrete over abstract, never a restatement of the title, and no assumption about the reader's age, wealth or fitness. Tests enforce length, non-restatement, and uniqueness.

## First steps are no longer one paragraph reused 175 times

`generateQuestChain` is templated on category alone, so every travel item rendered the same four paragraphs with a noun swapped. Fine inside the app where a user sees one; across 175 indexable pages it was most of the body.

`firstSteps()` weaves in each entry's own description, its region or horizon, and its cross-reference — a European destination no longer reads like an Asian one, and a milestone never reads like a place. The description is *quoted* rather than restated, since it's the lead paragraph directly above and an unattributed repeat reads like a mistake. A test holds bodies **above 95% unique** across the set.

`generateQuestChain` is untouched — it still drives the bucket-list quest chains users have already started.

## Facets

Twelve cross-cutting tags over all 122 hobbies, filterable on `/hobbies`. A category answers *what kind of thing is this*; a facet answers *would this fit my life*, which is the question someone with a bad knee or fifty pounds is actually asking.

`gentle`/`active` is required and mutually exclusive — an unlabelled hobby silently vanishes from the filter that matters most — and assigned strictly: kneeling, carrying, or standing for hours means `active`, Gardening included.

**Gentle + cheap + screen-free → 22 hobbies**, among them Walking, Bowling, Lawn bowls, Crosswords, Bridge, Choir, Mahjong. Two clicks, where this morning it was unanswerable.

## Checks

- 398 unit tests
- 118/118 e2e (13 new across two specs)
- typecheck, lint, docs:check clean
- Production build: 603 static pages, exit 0
- Sitemap 443 → 590

Recorded as `A11` in `docs/architecture/decisions.md`, including the constraint that a new idea without a sentence must not get a page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)