### PR TITLE
open a door from every hobby page into the 35 lives

### DIFF
--- a/e2e/hobby-facets.spec.ts
+++ b/e2e/hobby-facets.spec.ts
@@ -55,3 +55,32 @@ test.describe('Hobby facets', () => {
     expect(res.status()).toBe(200);
   });
 });
+
+/**
+ * The bridge into famous-journeys.ts — the largest content file in the repo,
+ * which until now had one inbound link from a page that is not in the nav.
+ */
+test.describe('Hobby pages reach the journeys', () => {
+  test('a hobby with a famous precedent links to that life', async ({ page }) => {
+    await page.goto('/hobbies/calligraphy');
+    await expect(page.getByRole('heading', { name: 'Who else picked this up' })).toBeVisible();
+
+    // Scoped to this section: a seeded public timeline at /u/stevejobs also
+    // links his name on this page, so an unscoped locator is ambiguous.
+    const link = page
+      .getByRole('heading', { name: 'Who else picked this up' })
+      .locator('xpath=following-sibling::ul[1]')
+      .getByRole('link', { name: /Steve Jobs/ });
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute('href');
+    expect(href).toBe('/journeys/steve-jobs');
+
+    const res = await page.request.get(href as string);
+    expect(res.status()).toBe(200);
+  });
+
+  test('a hobby with no precedent simply omits the section', async ({ page }) => {
+    await page.goto('/hobbies/lawn%20bowls');
+    await expect(page.getByRole('heading', { name: 'Who else picked this up' })).toHaveCount(0);
+  });
+});

--- a/src/app/hobbies/[hobby]/page.tsx
+++ b/src/app/hobbies/[hobby]/page.tsx
@@ -8,6 +8,7 @@ import { JsonLd } from '~/components/json-ld';
 import { Badge } from '~/components/ui/badge';
 import { timelines, users } from '~/db/schema';
 import { getEditorialArticlesForHobby } from '~/lib/editorial-content';
+import { journeysForHobby } from '~/lib/famous-journeys';
 import { getCategoryForHobby, HOBBY_CATEGORIES } from '~/lib/hobbies';
 import { getRelatedHobbies } from '~/lib/hobby-affinities';
 import { getResourcesForHobby } from '~/lib/hobby-resources';
@@ -96,6 +97,7 @@ export default async function HobbyDetailPage({ params }: Props) {
   const crossCategoryHobbies = getRelatedHobbies(hobbyName);
 
   const relatedPosts = getEditorialArticlesForHobby(hobbyName);
+  const mentions = journeysForHobby(hobbyName);
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-12">
@@ -219,6 +221,38 @@ export default async function HobbyDetailPage({ params }: Props) {
               </a>
             ))}
           </div>
+        </FadeIn>
+      )}
+
+      {/* Who else picked this up.
+          famous-journeys.ts is the largest content file in the repo and its
+          only inbound link was from /hobbies, which is not in the nav — two
+          hops from anywhere and effectively invisible. Each of these 122 pages
+          is now a door into it, and a named person who did the thing is a
+          better argument than any feature copy. */}
+      {mentions.length > 0 && (
+        <FadeIn className="mb-8" delay={0.1}>
+          <h2 className="mb-4 text-sm font-semibold text-muted-foreground">
+            Who else picked this up
+          </h2>
+          <ul className="divide-y divide-border border-border border-t">
+            {mentions.map((m) => (
+              <li key={m.slug} className="py-3">
+                <Link
+                  href={`/journeys/${m.slug}`}
+                  prefetch={false}
+                  className="text-base text-foreground underline-offset-4 hover:underline"
+                >
+                  {m.emoji} {m.name}
+                </Link>
+                <span className="text-base text-muted-foreground">
+                  {' '}
+                  — {m.phase.toLowerCase()}
+                  {m.as.toLowerCase() !== hobbyName.toLowerCase() ? `, as “${m.as}”` : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
         </FadeIn>
       )}
 

--- a/src/lib/famous-journeys.test.ts
+++ b/src/lib/famous-journeys.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { FAMOUS_JOURNEYS, journeysForHobby } from './famous-journeys';
+import { ALL_HOBBIES } from './hobbies';
+
+/**
+ * The bridge from the hobby catalogue into the 35 lives.
+ *
+ * famous-journeys.ts is the largest content file in the repo and had exactly
+ * one inbound link, from a page that is not itself in the nav. These tests
+ * hold the door open.
+ */
+describe('journeysForHobby', () => {
+  it('reaches a meaningful share of the catalogue', () => {
+    const covered = ALL_HOBBIES.filter((h) => journeysForHobby(h).length > 0);
+    expect(covered.length).toBeGreaterThan(50);
+  });
+
+  it('finds the matches worth finding', () => {
+    expect(journeysForHobby('Calligraphy').map((m) => m.name)).toContain('Steve Jobs');
+    expect(journeysForHobby('Chess').map((m) => m.name)).toContain('Bill Gates');
+  });
+
+  /**
+   * Whole-word, so a hobby is never matched by a longer word containing it.
+   *
+   * Note the limit: phase entries carry parentheticals, and a standalone word
+   * inside one is a legitimate hit — "Read" matches Franklin's "Reading
+   * (couldn't remember a time when he couldn't read)". That is the matcher
+   * working, not failing, and no catalogue hobby is a bare word fragment.
+   */
+  it('does not match on substrings', () => {
+    expect(journeysForHobby('Ches')).toHaveLength(0);
+    expect(journeysForHobby('Guita')).toHaveLength(0);
+    expect(journeysForHobby('alligraphy')).toHaveLength(0);
+  });
+
+  it('returns one mention per person, capped', () => {
+    for (const hobby of ALL_HOBBIES) {
+      const mentions = journeysForHobby(hobby);
+      expect(mentions.length).toBeLessThanOrEqual(4);
+      expect(new Set(mentions.map((m) => m.slug)).size).toBe(mentions.length);
+    }
+  });
+
+  it('only ever points at a journey that exists', () => {
+    const slugs = new Set(FAMOUS_JOURNEYS.map((j) => j.slug));
+    for (const hobby of ALL_HOBBIES) {
+      for (const m of journeysForHobby(hobby)) {
+        expect(slugs.has(m.slug), `${hobby} → ${m.slug}`).toBe(true);
+        expect(m.phase.length).toBeGreaterThan(0);
+        expect(m.as.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('is empty rather than throwing for an unknown hobby', () => {
+    expect(journeysForHobby('Nonexistent pastime')).toHaveLength(0);
+    expect(journeysForHobby('')).toHaveLength(0);
+  });
+});

--- a/src/lib/famous-journeys.ts
+++ b/src/lib/famous-journeys.ts
@@ -1604,3 +1604,62 @@ export const FAMOUS_JOURNEYS: FamousJourney[] = [
     },
   },
 ];
+
+// ─── Bridge to the hobby catalogue ───────────────────────────────────────────
+
+export type JourneyMention = {
+  slug: string;
+  name: string;
+  emoji: string;
+  /** The phase of their life this hobby appears in. */
+  phase: string;
+  /** Exactly how it is written in their timeline, which is often richer. */
+  as: string;
+};
+
+function normalise(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Which famous lives contain a given hobby, and when.
+ *
+ * `famous-journeys.ts` is the largest content file in the repo — 35 lives, 127
+ * phases — and until now its only inbound link was from `/hobbies`, which is
+ * itself not in the nav. It was two hops from anywhere and effectively
+ * invisible. This turns every one of the 122 hobby pages into a door into it.
+ *
+ * Matching is whole-word rather than substring, so "Reading" does not match
+ * "Proofreading" and "Chess" does not match "Chessboard collecting". A phase
+ * entry like "Walking meetings" does match "Walking", which is the intent —
+ * the timeline wording is kept in `as` so the page can show what they actually
+ * did rather than flattening it to the catalogue term.
+ */
+export function journeysForHobby(hobby: string, limit = 4): JourneyMention[] {
+  const needle = normalise(hobby);
+  if (!needle) return [];
+  const pattern = new RegExp(`\\b${needle.replace(/ /g, '\\s+')}\\b`);
+  const out: JourneyMention[] = [];
+
+  for (const journey of FAMOUS_JOURNEYS) {
+    for (const phase of journey.phases) {
+      const hit = phase.hobbies.find((h) => pattern.test(normalise(h)));
+      if (!hit) continue;
+      out.push({
+        slug: journey.slug,
+        name: journey.name,
+        emoji: journey.emoji,
+        phase: phase.label,
+        as: hit,
+      });
+      break; // One mention per person; the earliest phase is the interesting one.
+    }
+    if (out.length >= limit) break;
+  }
+
+  return out;
+}


### PR DESCRIPTION
`famous-journeys.ts` is the largest content file in the repo — 35 people, 127 life phases — and its only inbound link was from `/hobbies`, which is not itself in the nav. Two hops from anywhere, invisible in practice.

## Not a nav link, on purpose

`/journeys` is one of the three surfaces held back pending the quiz-funnel readout ([discovery-funnel.md](docs/product/discovery-funnel.md)), and that constraint stands.

A contextual link is stronger anyway. *"Steve Jobs — college / early career"* under **Calligraphy** argues for the hobby in a way a nav item never could.

## What it does

`journeysForHobby()` reverse-indexes the phase data. **60 of 122 hobbies** have at least one famous precedent; 127 mentions in total.

| Hobby | Who, and how the timeline puts it |
| --- | --- |
| Calligraphy | Steve Jobs — college / early career |
| Chess | Arnold Schwarzenegger, as *"daily games with his father from age 8"* |
| Guitar | Stephen King, as *"Guitar (self-taught)"* |
| Walking | Steve Jobs, as *"Walking meetings"* |

Matching is whole-word, so "Reading" never matches "Proofreading". The phase wording is kept verbatim in `as` and shown when it differs from the catalogue term — *"Bass guitar"* is more interesting than *"Guitar"*, and flattening it throws away the specific thing the person actually did.

## One honest limit

Phase entries carry parentheticals, so a standalone word inside one is a legitimate hit: `"Read"` matches Franklin's *"Reading (couldn't remember a time when he couldn't read)"*. That's the matcher working, and no catalogue hobby is a bare fragment. It's recorded in the test rather than pretended away — my first version of that test asserted the opposite and was wrong.

## Checks

- 404 unit tests (6 new)
- 120/120 e2e (2 new)
- typecheck, lint, docs:check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)