### PR TITLE
purge the whole zone on deploy, and smoke check a cached path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,19 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --minify
-      - name: Purge edge cache for landing HTML
-        # Best-effort: a missing zone cache_purge permission (401) must not fail a good deploy.
+      - name: Purge edge cache
+        # Purges the whole zone, not just `/`.
+        #
+        # worker.mjs edge-caches every path in its CACHEABLE_EXACT set and under
+        # its CACHEABLE_PREFIXES (/hobbies, /blog, /bucket-lists, /tools) with
+        # s-maxage=86400. Purging only `/` left all of those serving pre-deploy
+        # HTML for up to a day — a real deploy shipped a new /hobbies and
+        # production kept showing the old one, with the wrong hobby count and
+        # none of the new UI. The smoke check below only asserts on `/`, so
+        # nothing caught it.
+        #
+        # Best-effort: a missing zone cache_purge permission (401) must not fail
+        # a good deploy.
         continue-on-error: true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -49,8 +60,8 @@ jobs:
           curl -fsS -X POST "https://api.cloudflare.com/client/v4/zones/${zone_id}/purge_cache" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data '{"files":["https://significanthobbies.com/","https://www.significanthobbies.com/"]}'
-          echo "Purged / on significanthobbies.com"
+            --data '{"purge_everything":true}'
+          echo "Purged the whole zone for significanthobbies.com"
       - name: Smoke check production
         run: |
           html=$(curl -fsS --retry 3 --retry-delay 5 --max-time 20 \
@@ -74,3 +85,17 @@ jobs:
             exit 1
           fi
           echo "Overlay OK: ${sections} sections, LCP shell present"
+      - name: Smoke check a cached marketing page
+        # `/` is served by the Astro overlay and skips the Worker entirely, so
+        # asserting on it proves nothing about the edge-cached HTML paths. This
+        # checks one path that goes through worker.mjs's cache, which is where a
+        # stale-after-deploy failure actually shows up.
+        run: |
+          html=$(curl -fsS --retry 3 --retry-delay 5 --max-time 20 \
+            -H "Cache-Control: no-cache" https://significanthobbies.com/hobbies)
+          if ! printf '%s' "$html" | grep -q 'Browse by what suits you'; then
+            echo "ERROR: /hobbies is missing the facet browser — likely serving pre-deploy cached HTML."
+            echo "Purge the zone and re-check; see docs/operations/runbook.md."
+            exit 1
+          fi
+          echo "/hobbies OK: facet browser present, cache is post-deploy"

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -52,8 +52,21 @@ curl -fsS -X POST "https://api.cloudflare.com/client/v4/zones/$zone_id/purge_cac
   --data '{"files":["https://significanthobbies.com/","https://www.significanthobbies.com/"]}'
 ```
 
-The deploy workflow does this automatically, but if you push a landing change
-without a full deploy (e.g. hotfix the Astro overlay), purge manually.
+The deploy workflow purges the **whole zone** (`purge_everything`), not just
+`/`. It used to purge only the homepage, which left every edge-cached path
+serving pre-deploy HTML for up to a day: `worker.mjs` caches its
+`CACHEABLE_EXACT` set plus everything under `/hobbies`, `/blog`,
+`/bucket-lists` and `/tools` with `s-maxage=86400`. A deploy on 2026-07-26
+shipped a new `/hobbies` and production kept serving the previous one — right
+hobby count in the code, wrong one on the page.
+
+Use the single-file form above only for a landing hotfix that skips a full
+deploy (e.g. rebuilding the Astro overlay by hand).
+
+**Why `/` is not enough to verify a deploy:** anon `GET /` is static Astro HTML
+that skips the Worker entirely ([decisions.md](../architecture/decisions.md)
+A1), so it tells you nothing about the cached HTML paths. The deploy now smoke
+checks `/hobbies` as well, which does go through the Worker cache.
 
 ## Failure modes
 


### PR DESCRIPTION
Today's release succeeded and **production still served the old `/hobbies`** — the right hobby count in the code, the wrong one on the page, and none of the new facet UI.

## Cause

`worker.mjs` edge-caches its `CACHEABLE_EXACT` set plus everything under `/hobbies`, `/blog`, `/bucket-lists` and `/tools` with `s-maxage=86400`. The deploy purged **only `/`**. So every cached marketing path kept serving pre-deploy HTML for up to a day.

`/experiences` looked fine purely because it's new and not in the cache list — which is what made this present as a partial deploy rather than a cache problem.

## Changes

**Purge the whole zone.** `purge_everything` instead of two named files. When the cache list lives in the Worker rather than the workflow, invalidating everything is the only correct default for a deploy.

**Smoke check a path that goes through the Worker.** The existing check asserts on `/`, which anon requests serve as static Astro HTML that skips the Worker entirely ([decisions A1](docs/architecture/decisions.md)) — so it can pass while every Worker-rendered page is stale. That is precisely what happened. The new step fetches `/hobbies` and fails loudly with a pointer to the runbook.

## How it was found

Not from the workflow logs — those were all green, every step. Found by fetching the deployed pages and noticing `/hobbies` reported **108 hobbies where the committed catalogue has 122**.

Runbook updated with the cause, the distinction between the two purge forms, and why `/` alone cannot verify a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)