### PR TITLE
the deploy smoke check raced its own cache purge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,17 +85,39 @@ jobs:
             exit 1
           fi
           echo "Overlay OK: ${sections} sections, LCP shell present"
-      - name: Smoke check a cached marketing page
-        # `/` is served by the Astro overlay and skips the Worker entirely, so
-        # asserting on it proves nothing about the edge-cached HTML paths. This
-        # checks one path that goes through worker.mjs's cache, which is where a
-        # stale-after-deploy failure actually shows up.
+      - name: Smoke check a Worker-rendered page
+        # Two different questions, and only the first should fail a deploy.
+        #
+        # 1. Did the deploy ship correct code? Asked with a cache-busting query
+        #    param, because worker.mjs keys caches.default on the full request
+        #    URL — so `?cb=` is a guaranteed miss and a fresh SSR. A request
+        #    header of `Cache-Control: no-cache` is NOT enough: that is a hint to
+        #    the CDN, and the Worker's own cache.match() ignores it. Getting that
+        #    wrong made the first version of this step fail a good deploy.
+        #
+        # 2. Has the purge reached this colo yet? Asked without the param.
+        #    Cloudflare purge propagation is asynchronous, so a stale answer here
+        #    is a timing fact, not a broken release — it warns and moves on.
         run: |
-          html=$(curl -fsS --retry 3 --retry-delay 5 --max-time 20 \
-            -H "Cache-Control: no-cache" https://significanthobbies.com/hobbies)
-          if ! printf '%s' "$html" | grep -q 'Browse by what suits you'; then
-            echo "ERROR: /hobbies is missing the facet browser — likely serving pre-deploy cached HTML."
-            echo "Purge the zone and re-check; see docs/operations/runbook.md."
+          url=https://significanthobbies.com/hobbies
+          marker='Browse by what suits you'
+
+          fresh=$(curl -fsS --retry 3 --retry-delay 5 --max-time 20 "${url}?cb=${GITHUB_RUN_ID}")
+          if ! printf '%s' "$fresh" | grep -q "$marker"; then
+            echo "ERROR: a freshly rendered /hobbies is missing the facet browser."
+            echo "The deploy shipped code that does not render it — this is not a cache problem."
             exit 1
           fi
-          echo "/hobbies OK: facet browser present, cache is post-deploy"
+          echo "Deployed code OK: /hobbies renders the facet browser."
+
+          for attempt in 1 2 3 4 5 6; do
+            if curl -fsS --max-time 20 "$url" | grep -q "$marker"; then
+              echo "Edge cache OK: purge reached this colo after ${attempt} attempt(s)."
+              exit 0
+            fi
+            echo "Cached copy still stale (attempt ${attempt}/6) — waiting for purge to propagate."
+            sleep 15
+          done
+          echo "WARN: the cached /hobbies is still pre-deploy after ~90s."
+          echo "Purge propagation is asynchronous and s-maxage is 86400, so this"
+          echo "normally resolves on its own. See docs/operations/runbook.md."

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -65,8 +65,27 @@ deploy (e.g. rebuilding the Astro overlay by hand).
 
 **Why `/` is not enough to verify a deploy:** anon `GET /` is static Astro HTML
 that skips the Worker entirely ([decisions.md](../architecture/decisions.md)
-A1), so it tells you nothing about the cached HTML paths. The deploy now smoke
-checks `/hobbies` as well, which does go through the Worker cache.
+A1), so it tells you nothing about the cached HTML paths. The deploy also smoke
+checks `/hobbies`, which does go through the Worker cache.
+
+**Checking a cached page by hand.** `worker.mjs` keys `caches.default` on the
+full request URL, so a query string is a guaranteed miss:
+
+```bash
+# Fresh render — proves what the deployed code produces
+curl -s "https://significanthobbies.com/hobbies?cb=$RANDOM" | grep -c 'Browse by what suits you'
+
+# What a real visitor gets, plus whether it came from cache
+curl -sI https://significanthobbies.com/hobbies | grep -i x-edge-cache
+```
+
+A `Cache-Control: no-cache` **request header does not bypass the Worker cache** —
+it is a hint to the CDN, and `cache.match()` ignores it. Using it to verify a
+deploy will show you the stale copy and make a good release look broken.
+
+Purge propagation is asynchronous. A cached path can stay stale for a minute or
+two after `purge_everything` returns success; that is timing, not a failed
+deploy. Confirm with the cache-busted URL before concluding anything.
 
 ## Failure modes
 


### PR DESCRIPTION
The previous release **deployed correctly** and was marked failed by the check I added an hour earlier. Two mistakes in it, both mine.

## What was wrong

**It used a `Cache-Control: no-cache` request header to "bypass" the cache.** That's a hint to the CDN. `worker.mjs` calls `caches.default.match(request)` and ignores it entirely — so the check read the stale cached copy and concluded the deploy had shipped nothing.

**It ran once, immediately after the purge.** Cloudflare purge propagation is asynchronous; a stale answer at that moment is a timing fact, not a broken release.

## Now

Two questions, asked separately, and only the first can fail a deploy:

1. **Did we ship correct code?** Cache-busted with `?cb=$GITHUB_RUN_ID` — `worker.mjs` keys `caches.default` on the full request URL, so a query string is a guaranteed miss and a fresh SSR. A failure here is real.
2. **Has the purge reached this colo?** Plain URL, six attempts over ~90s, then warn and continue.

## Production was correct throughout

| | |
| --- | --- |
| `/hobbies` | 122 hobbies, facet browser present |
| `/experiences` | 322, all pages live |
| `/hobbies/calligraphy` | journeys bridge live |
| Sitemap | 580 URLs — 322 experiences + 35 journeys, 0 profiles (10 fewer than local, which seeds them) |

Verified by fetching with a cache-busting param, now documented in the runbook alongside the `x-edge-cache` header the Worker already sets — and with an explicit warning that `Cache-Control: no-cache` will show you the stale copy and make a good release look broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)