### PR TITLE
Make the public corpus agent-readable

### DIFF
--- a/.codex/skills/openspec-apply-change/SKILL.md
+++ b/.codex/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.codex/skills/openspec-archive-change/SKILL.md
+++ b/.codex/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.codex/skills/openspec-explore/SKILL.md
+++ b/.codex/skills/openspec-explore/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.codex/skills/openspec-propose/SKILL.md
+++ b/.codex/skills/openspec-propose/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.codex/skills/openspec-sync-specs/SKILL.md
+++ b/.codex/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the list of delta spec files.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   For each repo-local capability delta spec path returned by the CLI:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.codex/skills/openspec-update-change/SKILL.md
+++ b/.codex/skills/openspec-update-change/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: openspec-update-change
+description: Update an OpenSpec change by revising its existing planning artifacts and keeping them coherent with one another. Use when the user wants to revise a change's plan, fold new decisions into it, or reconcile its artifacts after an edit. Never edits code.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.6.0"
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to update.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx:continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx:continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx:apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx:archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx:continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx:apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx:continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, recommend starting fresh with `/opsx:new` (the "Update vs. Start Fresh" heuristic).

--- a/agent-edge.mjs
+++ b/agent-edge.mjs
@@ -39,7 +39,7 @@ export const AGENT_SURFACE = {
       {
         "id": "explore",
         "url": "https://significanthobbies.com/explore",
-        "md": null,
+        "md": "https://significanthobbies.com/explore.md",
         "kind": "static",
         "description": "Public hobby timelines"
       }

--- a/agent-route-markdown.mjs
+++ b/agent-route-markdown.mjs
@@ -1,0 +1,152 @@
+const PUBLIC_EXACT_PATHS = new Set([
+  '/',
+  '/about',
+  '/blog',
+  '/bucket-list-before-30',
+  '/bucket-list-before-50',
+  '/bucket-list-ideas',
+  '/bucket-lists',
+  '/changelog',
+  '/cheap-hobbies',
+  '/compare',
+  '/experiences',
+  '/explore',
+  '/find-your-hobby',
+  '/get-started',
+  '/hobbies',
+  '/hobbies-for-adults',
+  '/hobbies-for-mental-health',
+  '/hobbies-for-resume',
+  '/hobbies-to-try',
+  '/hobbies/random',
+  '/how-to-make-a-bucket-list',
+  '/journeys',
+  '/life-bingo',
+  '/life-in-weeks',
+  '/manifesto',
+  '/privacy',
+  '/search',
+  '/side-quests',
+  '/starter-kits',
+  '/terms',
+  '/tools',
+  '/tools/cost-calculator',
+  '/tools/time-calculator',
+  '/travel-bucket-list',
+  '/what-are-significant-hobbies',
+]);
+
+const PUBLIC_PATH_PREFIXES = [
+  '/blog/',
+  '/bucket-lists/',
+  '/experiences/',
+  '/hobbies/',
+  '/hobbies/category/',
+  '/journeys/',
+];
+
+const FIXED_AGENT_PATHS = new Set(['/api/ai', '/index.md', '/llms-full.txt', '/llms.txt']);
+
+/**
+ * Handle Markdown negotiation and explicit `.md` alternates for public
+ * server-rendered documents.
+ *
+ * `loadMarkdown` must read from the application's canonical route data rather
+ * than fetching this wrapper, so Markdown requests cannot recurse.
+ *
+ * @param {Request} request
+ * @param {(sourcePath: string, request: Request) => Promise<string | null>} loadMarkdown
+ * @returns {Promise<Response | null>}
+ */
+export async function handlePublicRouteMarkdown(request, loadMarkdown) {
+  if (request.method !== 'GET' && request.method !== 'HEAD') return null;
+
+  const requestedUrl = new URL(request.url);
+  if (FIXED_AGENT_PATHS.has(requestedUrl.pathname)) return null;
+
+  const explicitMarkdown = isMarkdownAlternatePath(requestedUrl.pathname);
+  const sourcePath = explicitMarkdown
+    ? htmlPathFromMarkdown(requestedUrl.pathname)
+    : normalizePath(requestedUrl.pathname);
+
+  if (explicitMarkdown && !isPublicAgentDocumentPath(sourcePath)) {
+    return markdownError(404, 'Not found', requestedUrl.pathname, request.method);
+  }
+  if (!explicitMarkdown && (!wantsMarkdown(request) || !isPublicAgentDocumentPath(sourcePath))) {
+    return null;
+  }
+
+  const markdown = await loadMarkdown(sourcePath, request);
+  if (!markdown) {
+    return markdownError(404, 'Public document unavailable', sourcePath, request.method);
+  }
+
+  const markdownPath = markdownPathFor(sourcePath);
+  return new Response(request.method === 'HEAD' ? null : markdown, {
+    status: 200,
+    headers: {
+      'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
+      'Content-Location': markdownPath,
+      'Content-Type': 'text/markdown; charset=utf-8',
+      Link: `<${sourcePath}>; rel="canonical"; type="text/html"`,
+      Vary: 'Accept',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}
+
+export function isPublicAgentDocumentPath(pathname) {
+  const path = normalizePath(pathname);
+  if (PUBLIC_EXACT_PATHS.has(path)) return true;
+  if (/^\/u\/[^/]+$/.test(path)) return true;
+  return PUBLIC_PATH_PREFIXES.some(
+    (prefix) => path.startsWith(prefix) && path.length > prefix.length
+  );
+}
+
+export function isAgentReadableSitemapPath(pathname) {
+  const path = normalizePath(pathname);
+  return FIXED_AGENT_PATHS.has(path) || isPublicAgentDocumentPath(path);
+}
+
+export function markdownPathFor(pathname) {
+  const path = normalizePath(pathname);
+  return path === '/' ? '/index.md' : `${path}.md`;
+}
+
+export function htmlPathFromMarkdown(pathname) {
+  const path = normalizePath(pathname);
+  if (path === '/index.md') return '/';
+  if (path.endsWith('/index.md')) return normalizePath(path.slice(0, -'/index.md'.length));
+  return normalizePath(path.slice(0, -'.md'.length));
+}
+
+function isMarkdownAlternatePath(pathname) {
+  return pathname.endsWith('.md');
+}
+
+function wantsMarkdown(request) {
+  if (request.headers.get('x-fleet-markdown-source') === '1') return false;
+  const accept = (request.headers.get('accept') || '').toLowerCase();
+  if (!accept.includes('text/markdown')) return false;
+  if (!accept.includes('text/html')) return true;
+  return accept.indexOf('text/markdown') < accept.indexOf('text/html');
+}
+
+function normalizePath(pathname) {
+  if (!pathname || pathname === '/') return '/';
+  const withLeadingSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return withLeadingSlash.replace(/\/{2,}/g, '/').replace(/\/+$/, '') || '/';
+}
+
+function markdownError(status, title, path, method) {
+  const body = `# ${title}\n\nNo public Markdown surface is available for \`${path}\`.\n`;
+  return new Response(method === 'HEAD' ? null : body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}

--- a/openspec/changes/serve-public-route-markdown/.openspec.yaml
+++ b/openspec/changes/serve-public-route-markdown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/serve-public-route-markdown/design.md
+++ b/openspec/changes/serve-public-route-markdown/design.md
@@ -1,0 +1,108 @@
+## Context
+
+Significant Hobbies is an OpenNext Worker with an Astro homepage overlay, Next
+server-rendered content routes, and a small generated edge handler for fixed
+agent discovery files. The sitemap mixes static pages, source-backed content
+families, and database-backed public profiles. Maintaining a second Markdown
+renderer for every route would duplicate product truth and inevitably drift.
+
+The existing Worker already sits in front of both Astro assets and OpenNext, so
+it is the only boundary that can cover the complete mixed corpus consistently.
+Public/private indexing remains defined by route patterns already represented in
+the sitemap; auth-only routes must not become Markdown surfaces. Because
+OpenNext streams React payloads, its initial response is not a complete
+server-rendered `<main>` that can be converted reliably.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Return useful Markdown for every public sitemap route through
+  `Accept: text/markdown`.
+- Resolve the corresponding `.md` alternate without exposing private routes or
+  returning an HTML shell for invalid agent paths.
+- Keep Markdown faithful to the same canonical data and route loaders used by
+  human pages.
+- Preserve the existing Astro/OpenNext runtime and caching boundaries.
+- Make the bounded `/api/ai` catalog internally consistent.
+
+**Non-Goals:**
+
+- Building a second editorial content system or copying the public corpus.
+- Indexing authenticated daily, settings, dashboard, or private timeline data.
+- Redesigning public pages, changing navigation, or deploying the Worker.
+- Adding third-party HTML/Markdown conversion packages.
+
+## Decisions
+
+### Render Markdown from canonical source data behind the Worker boundary
+
+The Worker will recognize only sitemap-owned public path families. For a
+negotiated route or `.md` alternate, it will call an internal Next route that
+dispatches the pathname to a source-backed Markdown renderer. The renderer
+imports the same hobby, experience, journey, bucket-list, editorial, and
+database loaders used by human routes. This avoids copying the 580 generated
+documents while producing complete content before React streaming.
+
+Converting OpenNext HTML was rejected after a local runtime probe showed that
+the initial response is a React/Flight shell rather than a complete `<main>`.
+Direct external refetching was rejected because it adds latency, recursion risk,
+and environment-dependent network behavior.
+
+```mermaid
+flowchart LR
+  A[Agent GET route or route.md] --> B[Worker public-path gate]
+  B --> C[Internal Markdown route]
+  C --> D[Canonical source and DB loaders]
+  D --> E[text/markdown response]
+  B -->|not public or no Markdown requested| F[Normal Astro/OpenNext response]
+```
+
+### Restrict Markdown generation to explicit public route families
+
+The path gate will include the exact public static routes and bounded dynamic
+families present in `sitemap.ts`. It will exclude authenticated and private
+application routes even if they happen to render a guest shell. Tests will
+compare every generated sitemap entry with the path gate, turning future sitemap
+growth into a deliberate Markdown-coverage decision.
+
+An unrestricted converter was rejected because `/daily.md` or
+`/settings.md` would contradict `/api/ai.auth` even when no personal data is
+returned.
+
+### Use a dependency-free, semantics-first source renderer
+
+The renderer will map canonical source objects into headings, paragraphs, lists,
+quotes, and links, normalize whitespace, and prepend a source URL. If no public
+source object exists, it will fail rather than label a guest/error shell as an
+agent-readable page.
+
+No production dependency is warranted. Unit tests cover each source family,
+empty/error results, full sitemap coverage, and private-route exclusion.
+
+### Treat fixed discovery surfaces separately
+
+`llms.txt`, `llms-full.txt`, `index.md`, and `/api/ai` remain fixed edge
+responses. `/api/ai` will advertise `/explore.md` for Explore, and both its URL
+and Markdown target will stay same-origin and sitemap-listed. Fixed files will
+not be routed through the document converter.
+
+### Correct metadata at route-family definitions
+
+Repeated SEO fixes belong in the `generateMetadata` functions for their route
+families. Each detail page will provide a self-referencing canonical, concise
+title that relies on the root title template only once, and a default OG image
+when no page-specific image exists.
+
+## Risks / Trade-offs
+
+- **Source schemas can change** → Import canonical typed loaders and cover every
+  current generated sitemap route in tests.
+- **A new sitemap family could lack Markdown** → A full generated-sitemap test
+  must fail until the public path gate is updated.
+- **SSR work adds cost for Markdown requests** → Reuse public cache headers and
+  cache successful Markdown at the edge; no extra work occurs for HTML traffic.
+- **Live source errors could otherwise become Markdown** → Return an explicit
+  Markdown failure when a public source object cannot be loaded.
+- **Generated `/api/ai` data can drift from the Fleet registry** → Update both
+  checked-in product payloads now and keep the Fleet registry aligned.

--- a/openspec/changes/serve-public-route-markdown/proposal.md
+++ b/openspec/changes/serve-public-route-markdown/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+The public sitemap contains roughly 580 routes, but the live Fleet GEO audit
+finds useful Markdown for only 2 of 250 sampled routes. Agents therefore discover
+the corpus but cannot reliably read it without HTML/JavaScript, while the
+existing `/api/ai` catalog advertises one surface whose Markdown target is
+missing.
+
+## What Changes
+
+- Add Markdown content negotiation and `.md` alternates for every public sitemap
+  route.
+- Derive Markdown from the same canonical source data and route loaders that
+  feed human pages, preserving headings, prose, lists, and links without relying
+  on streamed React HTML.
+- Keep fixed discovery files (`llms.txt`, `llms-full.txt`, `index.md`, and
+  `/api/ai`) authoritative and return explicit Markdown errors instead of HTML
+  shells for invalid `.md` paths.
+- Make `/api/ai` truthful by giving each bounded surface a same-origin Markdown
+  target that exists in the sitemap.
+- Correct repeated canonical, title, and social-image failures on representative
+  public content families without changing their visual design.
+
+## Capabilities
+
+### New Capabilities
+
+- `public-route-markdown`: Every sitemap-listed public document has a useful,
+  deterministic Markdown representation through negotiation and a `.md`
+  alternate.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `agent-edge.mjs` and `worker.mjs` gain an async public-document Markdown
+  boundary before OpenNext's normal HTML response path.
+- Public discovery catalog payloads and generated/static agent files stay
+  aligned.
+- Route-family metadata for hobbies, journeys, experiences, editorial articles,
+  and bucket lists gains self-referencing canonicals and complete social cards.
+- No new production dependencies, schema changes, migrations, redesign, or
+  deployment are required.

--- a/openspec/changes/serve-public-route-markdown/specs/public-route-markdown/spec.md
+++ b/openspec/changes/serve-public-route-markdown/specs/public-route-markdown/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Public sitemap routes are agent-readable
+
+The system SHALL return a useful Markdown representation for every public route
+listed in the sitemap without requiring client-side JavaScript.
+
+#### Scenario: Agent negotiates Markdown
+
+- **WHEN** a client requests a public sitemap route with
+  `Accept: text/markdown`
+- **THEN** the system returns HTTP 200 with a Markdown content type and the
+  route's public content
+
+#### Scenario: Agent requests a Markdown alternate
+
+- **WHEN** a client requests the `.md` alternate for a public sitemap route
+- **THEN** the system returns the same public content as Markdown with a link
+  back to the canonical human route
+
+### Requirement: Markdown stays truthful to the human document
+
+The system MUST derive route Markdown from the same canonical source data and
+loaders used by the human route and MUST preserve its meaningful headings,
+prose, lists, and links.
+
+#### Scenario: Content route is rendered
+
+- **WHEN** a source-backed or database-backed public route loads successfully
+- **THEN** its Markdown includes the document's primary heading, meaningful
+  prose, and canonical source URL without scripts or presentation markup
+
+#### Scenario: Human route fails
+
+- **WHEN** the underlying public source cannot be loaded
+- **THEN** the Markdown request fails explicitly and does not return an HTML
+  shell or a misleading success document
+
+### Requirement: Private routes remain excluded
+
+The system MUST NOT generate public Markdown for authenticated or private
+application routes that are absent from the public sitemap.
+
+#### Scenario: Private Markdown path is requested
+
+- **WHEN** a client requests a `.md` alternate for an authenticated route such
+  as `/daily` or `/settings`
+- **THEN** the agent boundary does not expose that route's content as Markdown
+
+### Requirement: Agent catalog surfaces are valid
+
+Every bounded surface in `/api/ai` SHALL have a same-origin URL present in the
+public sitemap and a same-origin Markdown target that returns readable Markdown.
+
+#### Scenario: Explore surface is discovered
+
+- **WHEN** an agent reads `/api/ai`
+- **THEN** the Explore surface advertises `/explore.md` and both `/explore` and
+  `/explore.md` resolve successfully under their respective content contracts
+
+### Requirement: Corpus coverage is regression-tested
+
+The repository SHALL verify that every route produced by its sitemap matches the
+public Markdown path boundary.
+
+#### Scenario: A new sitemap route family is introduced
+
+- **WHEN** the generated sitemap contains a route that is not covered by the
+  public Markdown boundary
+- **THEN** the full-corpus coverage check fails with the uncovered pathname

--- a/openspec/changes/serve-public-route-markdown/tasks.md
+++ b/openspec/changes/serve-public-route-markdown/tasks.md
@@ -1,0 +1,26 @@
+## 1. Agent Markdown Boundary
+
+- [x] 1.1 Add the public-route path gate, `.md` mapping, and dependency-free
+  canonical-source Markdown renderer.
+- [x] 1.2 Integrate negotiated and explicit Markdown responses before normal
+  Astro/OpenNext handling, including explicit non-HTML failures.
+- [x] 1.3 Align the checked-in `/api/ai`, `llms.txt`, and generated edge catalog
+  with the truthful public Markdown contract.
+
+## 2. Technical SEO
+
+- [x] 2.1 Add self-referencing canonicals and concise non-duplicated titles to
+  representative dynamic content families.
+- [x] 2.2 Ensure all audited public content families emit a valid social image
+  without changing their page design.
+- [x] 2.3 Make public hobby details degrade to useful indexable content when the
+  optional public-timeline query fails.
+
+## 3. Verification
+
+- [x] 3.1 Add focused unit tests for route mapping, source-render quality, catalog
+  integrity, and private-route exclusion.
+- [x] 3.2 Add a full generated-sitemap coverage test and run it against the
+  current corpus.
+- [x] 3.3 Run typecheck, focused/full tests, production build, OpenSpec strict
+  validation, representative local SEO audits, and the full local GEO audit.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/public/api-ai.json
+++ b/public/api-ai.json
@@ -21,7 +21,7 @@
     {
       "id": "explore",
       "url": "https://significanthobbies.com/explore",
-      "md": null,
+      "md": "https://significanthobbies.com/explore.md",
       "kind": "static",
       "description": "Public hobby timelines"
     }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,27 +1,35 @@
 # Significant Hobbies
 
-> Map your hobby history across life phases. Discover what rekindled, what persisted, and what to explore next — with shareable public journeys.
+> A life planner for private daily rituals and public living: hobbies, bucket
+> lists, experiences, and side quests over time.
 
-Next.js on Cloudflare Workers. Google auth for saving timelines; public explore and blog content for discovery.
+Next.js on Cloudflare Workers. Google auth is optional for saving private
+practice and timelines; the discovery corpus and opt-in profiles are public.
 
-## Product
+## Discover
 
-- [Home](https://significanthobbies.com/): Landing and value proposition
-- [Explore](https://significanthobbies.com/explore): Community timelines and inspiration
+- [Home](https://significanthobbies.com/): Product landing and life-planning frame
+- [Explore](https://significanthobbies.com/explore): Public hobby timelines
 - [Hobbies](https://significanthobbies.com/hobbies): Hobby taxonomy and category browse
-- [Blog](https://significanthobbies.com/blog): Articles on hobbies and life phases
-- [Full article index](https://significanthobbies.com/llms-full.txt): Canonical legacy and package-backed articles
-- [Start a timeline](https://significanthobbies.com/timeline/new): Create your journey (auth)
-- [Privacy](https://significanthobbies.com/privacy): Privacy policy
-- [Terms](https://significanthobbies.com/terms): Terms of use
+- [Experiences](https://significanthobbies.com/experiences): Things you could do and how to begin
+- [Famous journeys](https://significanthobbies.com/journeys): How hobbies changed across notable lives
+- [Bucket lists](https://significanthobbies.com/bucket-lists): Public lists and practical starting points
+- [Blog](https://significanthobbies.com/blog): Long-form articles about hobbies and living deliberately
 
-## SEO guides
+## Start
 
-- [What are significant hobbies?](https://significanthobbies.com/what-are-significant-hobbies): Concept explainer
-- [Hobbies for adults](https://significanthobbies.com/hobbies-for-adults): Starter guide
-- [Hobbies to try](https://significanthobbies.com/hobbies-to-try): Curated suggestions
+- [Find your hobby](https://significanthobbies.com/find-your-hobby): Guided hobby discovery
+- [Life in weeks](https://significanthobbies.com/life-in-weeks): Anonymous mortality and time-planning tool
+- [Life bingo](https://significanthobbies.com/life-bingo): Build a life list without an account
 
-## Optional
+## Agent access
 
-- [GitHub](https://github.com/sarthak-fleet/significanthobbies): Source
-- [Foundry](https://sassmaker.com): Fleet context
+- [Agent catalog](https://significanthobbies.com/api/ai): JSON inventory of bounded public surfaces
+- [Homepage Markdown](https://significanthobbies.com/index.md): Product brief without JavaScript
+- [Full article index](https://significanthobbies.com/llms-full.txt): Canonical editorial corpus
+- Every public sitemap route supports `Accept: text/markdown` and a `.md` alternate.
+- Authenticated daily practice and private user data are not agent-indexed.
+
+## Source
+
+- [GitHub](https://github.com/Significant-Hobbies/significanthobbies)

--- a/src/app/api/ai/markdown/route.ts
+++ b/src/app/api/ai/markdown/route.ts
@@ -1,0 +1,28 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { renderPublicRouteMarkdown } from '~/lib/public-route-markdown';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const path = request.nextUrl.searchParams.get('path');
+  if (!path?.startsWith('/')) {
+    return NextResponse.json({ error: 'A public path is required.' }, { status: 400 });
+  }
+
+  const markdown = await renderPublicRouteMarkdown(path);
+  if (!markdown) {
+    return new NextResponse('# Not found\n', {
+      status: 404,
+      headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    });
+  }
+
+  return new NextResponse(markdown, {
+    status: 200,
+    headers: {
+      'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400',
+      'Content-Type': 'text/markdown; charset=utf-8',
+    },
+  });
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -11,11 +11,26 @@ import {
 } from '~/components/aceternity';
 import type { BlogPost } from '~/lib/blog-posts';
 import { editorialArticles } from '~/lib/editorial-content';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 
+const description =
+  'Thoughts on hobbies, identity, and living curiously. Articles on the psychology of leisure, rekindled passions, and finding what matters.';
 export const metadata: Metadata = {
-  title: 'Blog',
-  description:
-    'Thoughts on hobbies, identity, and living curiously. Articles on the psychology of leisure, rekindled passions, and finding what matters.',
+  title: { absolute: 'Hobby psychology, identity, and practical guides' },
+  description,
+  alternates: { canonical: `${SITE_URL}/blog` },
+  openGraph: {
+    title: 'Hobby psychology, identity, and practical guides',
+    description,
+    url: `${SITE_URL}/blog`,
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Hobby psychology, identity, and practical guides',
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE],
+  },
 };
 
 const CATEGORY_COLORS: Record<string, { bg: string; text: string; border: string }> = {

--- a/src/app/bucket-lists/[slug]/page.tsx
+++ b/src/app/bucket-lists/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
   FAMOUS_BUCKET_LISTS,
   getFamousBucketList,
 } from '~/lib/famous-bucket-lists';
+import { DEFAULT_SOCIAL_IMAGE } from '~/lib/site-metadata';
 import { getServerAuthSession } from '~/server/auth';
 
 type Props = { params: Promise<{ slug: string }> };
@@ -29,12 +30,22 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const list = getFamousBucketList(slug);
   if (!list) return {};
   const done = list.items.filter((i) => i.status === 'done').length;
+  const title = `${list.name}'s bucket list: ${list.items.length} verified ideas`;
+  const description = `${list.items.length} verified bucket list items from ${list.name}. ${done} completed. ${list.knownFor}. Add any item to your own bucket list.`;
   return {
-    title: `${list.name}'s Bucket List (${done} completed) — SignificantHobbies`,
-    description: `${list.items.length} verified bucket list items from ${list.name}. ${done} completed. ${list.knownFor}. Add any item to your own bucket list.`,
+    title: { absolute: title },
+    description,
     openGraph: {
-      title: `${list.name}'s Bucket List`,
-      description: `${done} of ${list.items.length} items completed. Browse and add to your own list.`,
+      title,
+      description,
+      url: `/bucket-lists/${slug}`,
+      images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [DEFAULT_SOCIAL_IMAGE],
     },
     alternates: { canonical: `https://significanthobbies.com/bucket-lists/${slug}` },
   };

--- a/src/app/bucket-lists/page.tsx
+++ b/src/app/bucket-lists/page.tsx
@@ -12,15 +12,25 @@ import {
 } from '~/components/aceternity';
 import { Whale } from '~/components/whale';
 import { BUCKET_ITEM_CATEGORIES, FAMOUS_BUCKET_LISTS } from '~/lib/famous-bucket-lists';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 
+const description =
+  'Create bucket lists that mean something. Browse verified public lists, practical ideas, and anonymous tools for planning what matters.';
 export const metadata: Metadata = {
-  title: 'Bucket Lists — SignificantHobbies',
-  description:
-    'Explore the bucket lists of presidents, athletes, billionaires, and icons. Find the life you want to live.',
+  title: { absolute: 'Bucket lists for what matters' },
+  description,
+  alternates: { canonical: `${SITE_URL}/bucket-lists` },
   openGraph: {
-    title: "What do the world's most remarkable people want to do before they die?",
-    description:
-      'Browse verified bucket lists from Will Smith, Obama, Serena Williams, Elon Musk and more. Find your next great ambition.',
+    title: 'Bucket lists for what matters',
+    description,
+    url: `${SITE_URL}/bucket-lists`,
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Bucket lists for what matters',
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE],
   },
 };
 

--- a/src/app/experiences/[slug]/page.tsx
+++ b/src/app/experiences/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
   relatedExperiences,
 } from '~/lib/experiences';
 import { safeDecodeURIComponent } from '~/lib/slug';
+import { DEFAULT_SOCIAL_IMAGE } from '~/lib/site-metadata';
 
 /**
  * A page per experience — but only for the ones carrying written prose.
@@ -41,7 +42,7 @@ export async function generateMetadata({
   const entry = resolve((await params).slug);
   if (!entry) return { title: 'Not found — SignificantHobbies' };
   return {
-    title: `${entry.title} — SignificantHobbies`,
+    title: { absolute: entry.title },
     description: entry.description,
     alternates: { canonical: `/experiences/${entry.slug}` },
     openGraph: {
@@ -49,6 +50,13 @@ export async function generateMetadata({
       description: entry.description,
       url: `/experiences/${entry.slug}`,
       type: 'article',
+      images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: entry.title,
+      description: entry.description,
+      images: [DEFAULT_SOCIAL_IMAGE],
     },
   };
 }

--- a/src/app/experiences/page.tsx
+++ b/src/app/experiences/page.tsx
@@ -2,19 +2,27 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { EXPERIENCE_CATEGORIES, EXPERIENCE_ENTRIES } from '~/lib/experiences';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 import { ExperiencesClient } from './experiences-client';
 
+const description =
+  'Every experience we know about, in one searchable list: places to go, milestones to reach, and ideas worth stealing. No account needed.';
 export const metadata: Metadata = {
-  title: 'Things You Could Do — SignificantHobbies',
-  description:
-    'Every experience we know about, in one searchable list: places to go, milestones to reach, and ideas worth stealing. No account needed.',
+  title: { absolute: 'Experiences worth making room for' },
+  description,
   alternates: { canonical: '/experiences' },
   openGraph: {
-    title: 'Things You Could Do',
-    description:
-      'Every experience we know about, in one searchable list — places, milestones and ideas.',
-    url: '/experiences',
+    title: 'Experiences worth making room for',
+    description,
+    url: `${SITE_URL}/experiences`,
     type: 'website',
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Experiences worth making room for',
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE],
   },
 };
 

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,21 +1,38 @@
 export const revalidate = 300;
 
 import { count, desc, eq, inArray } from 'drizzle-orm';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { FadeIn, GridBackground } from '~/components/aceternity';
 import { likes, timelines, users } from '~/db/schema';
 import { getCategoryForHobby } from '~/lib/hobbies';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 import type { Phase, TimelineData, TimelineVisibility } from '~/lib/types';
 import { parseJSONColumn } from '~/lib/utils';
 import { db } from '~/server/db';
 
 import { ExploreClient } from './explore-client';
 
-export const metadata = {
-  title: 'Explore Hobby Timelines — SignificantHobbies',
-  description:
-    'Discover how people spend their time across life phases. Browse community hobby timelines, trending interests, and inspiring journeys.',
+const description =
+  'Discover how people spend their time across life phases. Browse community hobby timelines, trending interests, and inspiring journeys.';
+
+export const metadata: Metadata = {
+  title: { absolute: 'Explore public hobby timelines' },
+  description,
+  alternates: { canonical: `${SITE_URL}/explore` },
+  openGraph: {
+    title: 'Explore public hobby timelines',
+    description,
+    url: `${SITE_URL}/explore`,
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Explore public hobby timelines',
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE],
+  },
 };
 
 export default async function ExplorePage() {

--- a/src/app/hobbies/[hobby]/page.tsx
+++ b/src/app/hobbies/[hobby]/page.tsx
@@ -14,6 +14,7 @@ import { getRelatedHobbies } from '~/lib/hobby-affinities';
 import { getResourcesForHobby } from '~/lib/hobby-resources';
 import { getRoadmapForHobby } from '~/lib/hobby-roadmap';
 import { safeDecodeURIComponent } from '~/lib/slug';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 import { getTimelineUrl } from '~/lib/timeline-url';
 import type { Phase } from '~/lib/types';
 import { parseJSONColumn } from '~/lib/utils';
@@ -46,9 +47,24 @@ export async function generateMetadata({ params }: Props) {
   const decoded = safeDecodeURIComponent(hobby);
   if (!decoded) return {};
   const name = slugToHobby(decoded);
+  const canonical = `${SITE_URL}/hobbies/${encodeURIComponent(decoded)}`;
+  const description = `Explore ${name} — see community timelines, find tools and resources, and discover related hobbies on Significant Hobbies.`;
   return {
-    title: `${name} — SignificantHobbies`,
-    description: `Explore ${name} — see community timelines, find tools and resources, and discover related hobbies on SignificantHobbies.`,
+    title: { absolute: `${name}: roadmap, resources, and ideas` },
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title: `${name}: roadmap, resources, and ideas`,
+      description,
+      url: canonical,
+      images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${name}: roadmap, resources, and ideas`,
+      description,
+      images: [DEFAULT_SOCIAL_IMAGE],
+    },
   };
 }
 
@@ -65,21 +81,7 @@ export default async function HobbyDetailPage({ params }: Props) {
   const isLoggedIn = !!session?.user;
 
   // Find public timelines that include this hobby
-  const rawTimelines = await db
-    .select({
-      id: timelines.id,
-      title: timelines.title,
-      slug: timelines.slug,
-      phases: timelines.phases,
-      updatedAt: timelines.updatedAt,
-      userName: users.name,
-      userUsername: users.username,
-    })
-    .from(timelines)
-    .leftJoin(users, eq(timelines.userId, users.id))
-    .where(eq(timelines.visibility, 'PUBLIC'))
-    .orderBy(desc(timelines.updatedAt))
-    .limit(50);
+  const rawTimelines = await loadRecentPublicTimelines();
 
   const matchingTimelines = rawTimelines.filter((t) => {
     const phases = parseJSONColumn<Phase[]>(t.phases, [], 'hobby-detail:filter:phases');
@@ -392,4 +394,27 @@ export default async function HobbyDetailPage({ params }: Props) {
       )}
     </div>
   );
+}
+
+async function loadRecentPublicTimelines() {
+  try {
+    return await db
+      .select({
+        id: timelines.id,
+        title: timelines.title,
+        slug: timelines.slug,
+        phases: timelines.phases,
+        updatedAt: timelines.updatedAt,
+        userName: users.name,
+        userUsername: users.username,
+      })
+      .from(timelines)
+      .leftJoin(users, eq(timelines.userId, users.id))
+      .where(eq(timelines.visibility, 'PUBLIC'))
+      .orderBy(desc(timelines.updatedAt))
+      .limit(50);
+  } catch (error) {
+    console.error('[hobby-detail] public timeline query failed', error);
+    return [];
+  }
 }

--- a/src/app/hobbies/page.tsx
+++ b/src/app/hobbies/page.tsx
@@ -1,4 +1,5 @@
 import { ArrowRight } from 'lucide-react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import {
@@ -10,13 +11,29 @@ import {
 } from '~/components/aceternity';
 import { categoryImageSrc, categoryImageSrcSet } from '~/lib/category-images';
 import { HOBBY_CATEGORIES } from '~/lib/hobbies';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 import { cn } from '~/lib/utils';
 import { HobbyFacetsClient } from './hobby-facets-client';
 
-export const metadata = {
-  title: 'Hobby Directory — SignificantHobbies',
-  description:
-    'Browse 110+ hobbies across 10 categories. Find your next passion — from creative arts and music to outdoor adventures and making.',
+const description =
+  'Browse 110+ hobbies across 10 categories. Find your next passion — from creative arts and music to outdoor adventures and making.';
+
+export const metadata: Metadata = {
+  title: { absolute: 'Hobby directory: 110+ pursuits to explore' },
+  description,
+  alternates: { canonical: `${SITE_URL}/hobbies` },
+  openGraph: {
+    title: 'Hobby directory: 110+ pursuits to explore',
+    description,
+    url: `${SITE_URL}/hobbies`,
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Hobby directory: 110+ pursuits to explore',
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE],
+  },
 };
 
 export default function HobbiesPage() {

--- a/src/app/journeys/[slug]/page.tsx
+++ b/src/app/journeys/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
   StaggerItem,
 } from '~/components/aceternity';
 import { FAMOUS_JOURNEYS } from '~/lib/famous-journeys';
+import { BRAND_NAME, DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -26,10 +27,27 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const firstPhaseLabel = person.phases[0]?.label ?? 'early life';
   const lastPhaseLabel = person.phases[person.phases.length - 1]?.label ?? 'peak career';
+  const canonical = `${SITE_URL}/journeys/${person.slug}`;
+  const title = `${person.name}'s hobby journey — ${BRAND_NAME}`;
+  const description = `Explore ${person.name}'s hobby journey — from ${firstPhaseLabel} to ${lastPhaseLabel}. See how their hobbies shaped who they became.`;
 
   return {
-    title: `${person.name}'s Hobbies — SignificantHobbies`,
-    description: `Explore ${person.name}'s hobby journey — from ${firstPhaseLabel} to ${lastPhaseLabel}. See how their hobbies shaped who they became.`,
+    title: { absolute: title },
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: 'article',
+      title,
+      description,
+      url: canonical,
+      images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [DEFAULT_SOCIAL_IMAGE],
+    },
   };
 }
 

--- a/src/app/journeys/page.tsx
+++ b/src/app/journeys/page.tsx
@@ -11,11 +11,26 @@ import {
   TextGenerateEffect,
 } from '~/components/aceternity';
 import { FAMOUS_JOURNEYS } from '~/lib/famous-journeys';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 
+const description =
+  "Explore how hobbies shaped famous lives—from Steve Jobs' calligraphy to Einstein's violin—across childhood, career, and reinvention.";
 export const metadata: Metadata = {
-  title: 'Famous Hobby Journeys — SignificantHobbies',
-  description:
-    "Explore how famous people's hobbies shaped who they became. From Steve Jobs' calligraphy to Einstein's violin — discover the hobby timelines of remarkable people.",
+  title: { absolute: 'Famous hobby journeys across remarkable lives' },
+  description,
+  alternates: { canonical: `${SITE_URL}/journeys` },
+  openGraph: {
+    title: 'Famous hobby journeys across remarkable lives',
+    description,
+    url: `${SITE_URL}/journeys`,
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Famous hobby journeys across remarkable lives',
+    description,
+    images: [DEFAULT_SOCIAL_IMAGE],
+  },
 };
 
 export default function JourneysPage() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -272,6 +272,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.6,
     },
     {
+      url: `${baseUrl}/changelog`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
       url: `${baseUrl}/search`,
       lastModified: now,
       changeFrequency: 'weekly',

--- a/src/lib/agent-route-markdown.test.ts
+++ b/src/lib/agent-route-markdown.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import sitemap from '~/app/sitemap';
+import { editorialArticles } from '~/lib/editorial-content';
+import { PAGED_EXPERIENCES } from '~/lib/experiences';
+import { FAMOUS_JOURNEYS } from '~/lib/famous-journeys';
+import apiCatalog from '../../public/api-ai.json';
+import {
+  handlePublicRouteMarkdown,
+  htmlPathFromMarkdown,
+  isAgentReadableSitemapPath,
+  isPublicAgentDocumentPath,
+  markdownPathFor,
+} from '../../agent-route-markdown.mjs';
+import { renderPublicRouteMarkdown } from '~/lib/public-route-markdown';
+
+describe('public route Markdown boundary', () => {
+  it('maps explicit Markdown alternates to their public documents', () => {
+    expect(markdownPathFor('/hobbies/painting')).toBe('/hobbies/painting.md');
+    expect(htmlPathFromMarkdown('/hobbies/painting.md')).toBe('/hobbies/painting');
+    expect(htmlPathFromMarkdown('/hobbies/painting/index.md')).toBe('/hobbies/painting');
+    expect(markdownPathFor('/')).toBe('/index.md');
+  });
+
+  it('covers public route families but excludes private application routes', () => {
+    expect(isPublicAgentDocumentPath('/experiences/see-the-northern-lights')).toBe(true);
+    expect(isPublicAgentDocumentPath('/hobbies/category/creative')).toBe(true);
+    expect(isPublicAgentDocumentPath('/u/public-person')).toBe(true);
+    expect(isPublicAgentDocumentPath('/u/public-person/unlisted-timeline')).toBe(false);
+    expect(isPublicAgentDocumentPath('/daily')).toBe(false);
+    expect(isPublicAgentDocumentPath('/settings')).toBe(false);
+    expect(isPublicAgentDocumentPath('/timeline/private-id')).toBe(false);
+  });
+
+  it('negotiates Markdown from the canonical route source', async () => {
+    const load = vi.fn(async (path: string) => renderPublicRouteMarkdown(path));
+    const response = await handlePublicRouteMarkdown(
+      new Request('https://significanthobbies.com/hobbies/painting', {
+        headers: { Accept: 'text/markdown, text/html;q=0.1' },
+      }),
+      load
+    );
+
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get('content-type')).toBe('text/markdown; charset=utf-8');
+    expect(response?.headers.get('content-location')).toBe('/hobbies/painting.md');
+    expect(await response?.text()).toContain('# Painting');
+    expect(load).toHaveBeenCalledWith('/hobbies/painting', expect.any(Request));
+  });
+
+  it('returns explicit Markdown failures instead of exposing private or empty shells', async () => {
+    const privateResponse = await handlePublicRouteMarkdown(
+      new Request('https://significanthobbies.com/daily.md'),
+      vi.fn()
+    );
+    expect(privateResponse?.status).toBe(404);
+    expect(privateResponse?.headers.get('content-type')).toContain('text/markdown');
+
+    const emptyResponse = await handlePublicRouteMarkdown(
+      new Request('https://significanthobbies.com/explore.md'),
+      async () => null
+    );
+    expect(emptyResponse?.status).toBe(404);
+    expect(await emptyResponse?.text()).not.toContain('<html>');
+  });
+
+  it('renders every generated public corpus route from canonical source data', async () => {
+    const entries = await sitemap();
+    const paths = entries.map((entry) => new URL(entry.url).pathname);
+    const uncovered = paths.filter((path) => !isAgentReadableSitemapPath(path));
+    const staticCorpus = paths.filter(
+      (path) =>
+        !path.startsWith('/u/') && !['/index.md', '/llms-full.txt', '/llms.txt'].includes(path)
+    );
+    const rendered = await Promise.all(
+      staticCorpus.map(async (path) => [path, await renderPublicRouteMarkdown(path)] as const)
+    );
+
+    expect(entries.length).toBeGreaterThan(500);
+    expect(uncovered).toEqual([]);
+    expect(rendered.filter(([, markdown]) => markdown === null).map(([path]) => path)).toEqual([]);
+  });
+
+  it('renders substantive Markdown for each public content family', async () => {
+    const hobby = await renderPublicRouteMarkdown('/hobbies/drawing');
+    const experience = await renderPublicRouteMarkdown(
+      `/experiences/${PAGED_EXPERIENCES[0]!.slug}`
+    );
+    const journey = await renderPublicRouteMarkdown(`/journeys/${FAMOUS_JOURNEYS[0]!.slug}`);
+    const blog = await renderPublicRouteMarkdown(`/blog/${editorialArticles[0]!.slug}`);
+
+    expect(hobby).toContain('## A path from today to three months');
+    expect(hobby).toContain('## Resources');
+    expect(experience).toContain('## How to start');
+    expect(journey).toContain(FAMOUS_JOURNEYS[0]!.name);
+    expect(blog).toContain('> Source: https://significanthobbies.com/blog/');
+    expect(await renderPublicRouteMarkdown('/daily')).toBeNull();
+  });
+
+  it('advertises only bounded surfaces with real same-origin Markdown targets', () => {
+    const publicRoutes = new Set(['/', '/explore']);
+
+    expect(apiCatalog.surfaces).toHaveLength(2);
+    for (const surface of apiCatalog.surfaces) {
+      const url = new URL(surface.url);
+      const markdown = new URL(surface.md);
+      expect(url.origin).toBe(apiCatalog.url);
+      expect(markdown.origin).toBe(apiCatalog.url);
+      expect(publicRoutes.has(url.pathname)).toBe(true);
+      expect(
+        markdown.pathname === '/index.md' ||
+          isPublicAgentDocumentPath(htmlPathFromMarkdown(markdown.pathname))
+      ).toBe(true);
+    }
+  });
+});

--- a/src/lib/editorial-seo.test.ts
+++ b/src/lib/editorial-seo.test.ts
@@ -69,7 +69,10 @@ describe('editorial discovery and structured data', () => {
       title: article.title,
       description: article.excerpt,
     });
-    expect(metadata.twitter).toMatchObject({ card: 'summary' });
+    expect(metadata.twitter).toMatchObject({
+      card: 'summary_large_image',
+      images: ['https://significanthobbies.com/opengraph-image'],
+    });
     expect(jsonLd).toMatchObject({
       '@type': 'Article',
       headline: article.title,

--- a/src/lib/editorial-seo.ts
+++ b/src/lib/editorial-seo.ts
@@ -1,8 +1,7 @@
 import type { Metadata } from 'next';
 
 import type { EditorialArticle } from '~/lib/editorial-content';
-
-const SITE_URL = 'https://significanthobbies.com';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 
 export function articleCanonicalUrl(article: EditorialArticle): string {
   return `${SITE_URL}/blog/${article.slug}`;
@@ -13,7 +12,7 @@ export function buildArticleMetadata(article: EditorialArticle): Metadata {
   const thumbnail = article.package?.youtube?.thumbnailUrl;
 
   return {
-    title: article.title,
+    title: { absolute: article.title },
     description: article.excerpt,
     alternates: { canonical },
     openGraph: {
@@ -21,15 +20,14 @@ export function buildArticleMetadata(article: EditorialArticle): Metadata {
       url: canonical,
       title: article.title,
       description: article.excerpt,
-      ...(thumbnail
-        ? { images: [{ url: thumbnail }], videos: [{ url: article.package!.youtube!.url }] }
-        : {}),
+      images: [{ url: thumbnail ?? DEFAULT_SOCIAL_IMAGE }],
+      ...(thumbnail ? { videos: [{ url: article.package!.youtube!.url }] } : {}),
     },
     twitter: {
-      card: thumbnail ? 'summary_large_image' : 'summary',
+      card: 'summary_large_image',
       title: article.title,
       description: article.excerpt,
-      ...(thumbnail ? { images: [thumbnail] } : {}),
+      images: [thumbnail ?? DEFAULT_SOCIAL_IMAGE],
     },
   };
 }

--- a/src/lib/public-route-markdown.ts
+++ b/src/lib/public-route-markdown.ts
@@ -1,0 +1,498 @@
+import { and, desc, eq } from 'drizzle-orm';
+
+import { timelines, users } from '~/db/schema';
+import { getEditorialArticle, editorialArticles } from '~/lib/editorial-content';
+import {
+  EXPERIENCE_ENTRIES,
+  findExperience,
+  firstSteps,
+  relatedExperiences,
+} from '~/lib/experiences';
+import { FAMOUS_BUCKET_LISTS, getFamousBucketList } from '~/lib/famous-bucket-lists';
+import { FAMOUS_JOURNEYS } from '~/lib/famous-journeys';
+import { getCategoryForHobby, HOBBY_CATEGORIES } from '~/lib/hobbies';
+import { getRelatedHobbies } from '~/lib/hobby-affinities';
+import { getResourcesForHobby } from '~/lib/hobby-resources';
+import { getRoadmapForHobby } from '~/lib/hobby-roadmap';
+import { parseJSONColumn } from '~/lib/utils';
+import { db } from '~/server/db';
+import type { Phase } from '~/lib/types';
+
+const SITE_URL = 'https://significanthobbies.com';
+
+const STATIC_PAGES: Record<string, { title: string; summary: string }> = {
+  '/about': {
+    title: 'About Significant Hobbies',
+    summary:
+      'A life planner for private daily rituals and public living: hobbies, bucket lists, experiences, side quests, and opt-in profiles.',
+  },
+  '/bucket-list-before-30': {
+    title: 'Bucket list ideas before 30',
+    summary: 'Milestones and experiences people often want to make room for before 30.',
+  },
+  '/bucket-list-before-50': {
+    title: 'Bucket list ideas before 50',
+    summary: 'Meaningful experiences, relationships, and achievements to consider before 50.',
+  },
+  '/bucket-list-ideas': {
+    title: 'Bucket list ideas',
+    summary: 'A large categorized collection of travel, creative, social, and personal ambitions.',
+  },
+  '/changelog': {
+    title: 'Significant Hobbies changelog',
+    summary: 'Verified improvements to daily reflection, hobby discovery, and life planning.',
+  },
+  '/cheap-hobbies': {
+    title: 'Free and cheap hobbies',
+    summary: 'Low-cost hobbies with practical ways to begin without buying a large starter kit.',
+  },
+  '/compare': {
+    title: 'Compare hobbies',
+    summary: 'Compare two hobbies by cost, energy, setting, social style, and learning curve.',
+  },
+  '/find-your-hobby': {
+    title: 'Find your hobby',
+    summary: 'A guided quiz that matches interests, constraints, and preferred pace to hobbies.',
+  },
+  '/get-started': {
+    title: 'Get started with Significant Hobbies',
+    summary: 'Choose a username and begin a hobby timeline; guest exploration remains available.',
+  },
+  '/hobbies-for-adults': {
+    title: 'Hobbies for adults',
+    summary:
+      'A practical directory of adult hobbies across creative, physical, social, and quiet pursuits.',
+  },
+  '/hobbies-for-mental-health': {
+    title: 'Hobbies for mental health',
+    summary: 'Evidence-aware hobby ideas for attention, connection, movement, and stress relief.',
+  },
+  '/hobbies-for-resume': {
+    title: 'Hobbies for a resume',
+    summary:
+      'How to describe genuine hobbies when they demonstrate relevant skills or sustained commitment.',
+  },
+  '/hobbies-to-try': {
+    title: 'New hobbies to try',
+    summary:
+      'Beginner-friendly and more adventurous pursuits, organized by the experience they offer.',
+  },
+  '/hobbies/random': {
+    title: 'Random hobby',
+    summary:
+      'A randomized prompt from the Significant Hobbies catalog for breaking choice paralysis.',
+  },
+  '/how-to-make-a-bucket-list': {
+    title: 'How to make a bucket list',
+    summary:
+      'A practical method for choosing meaningful ambitions and turning one into a next step.',
+  },
+  '/life-bingo': {
+    title: 'Life bingo',
+    summary: 'An anonymous tool for arranging experiences into a personal life-list board.',
+  },
+  '/life-in-weeks': {
+    title: 'Your life in weeks',
+    summary:
+      'An anonymous life grid that uses conditional life expectancy to frame the time ahead.',
+  },
+  '/manifesto': {
+    title: 'The Significant Hobbies manifesto',
+    summary:
+      'A case for treating attention and leisure as parts of a life rather than leftover time.',
+  },
+  '/privacy': {
+    title: 'Privacy',
+    summary:
+      'How Significant Hobbies handles accounts, private practice, public sharing, and analytics.',
+  },
+  '/search': {
+    title: 'Search Significant Hobbies',
+    summary: 'Search public hobbies, experiences, editorial guides, and life-planning resources.',
+  },
+  '/side-quests': {
+    title: 'Side quests',
+    summary: 'Small, low-stakes experiments for exploring life outside the main obligations.',
+  },
+  '/starter-kits': {
+    title: 'Local hobby starter kits',
+    summary: 'Practical first supplies and local starting points for common hobbies.',
+  },
+  '/terms': {
+    title: 'Terms of use',
+    summary: 'The terms that govern use of Significant Hobbies.',
+  },
+  '/tools': {
+    title: 'Hobby tools',
+    summary: 'Free calculators for understanding available time and the real cost of a hobby.',
+  },
+  '/tools/cost-calculator': {
+    title: 'Hobby cost calculator',
+    summary: 'Estimate setup and ongoing costs before committing to a hobby.',
+  },
+  '/tools/time-calculator': {
+    title: 'Hobby time calculator',
+    summary:
+      'Estimate realistic weekly time for a hobby around work, sleep, and existing obligations.',
+  },
+  '/travel-bucket-list': {
+    title: 'Travel bucket list',
+    summary: 'Destinations and travel experiences organized by region and type of trip.',
+  },
+  '/what-are-significant-hobbies': {
+    title: 'What are significant hobbies?',
+    summary:
+      'How hobbies become meaningful through identity, relationships, seasons of life, and sustained attention.',
+  },
+};
+
+export async function renderPublicRouteMarkdown(pathname: string): Promise<string | null> {
+  const path = normalizePath(pathname);
+  const source = `${SITE_URL}${path === '/' ? '' : path}`;
+
+  if (path === '/') {
+    return page(
+      'Significant Hobbies',
+      source,
+      'A life planner for private daily rituals and public living.',
+      [
+        'Explore hobbies, experiences, bucket lists, and famous hobby journeys.',
+        'Use the anonymous life-in-weeks and life-bingo tools without creating an account.',
+        'Private daily practice and saved timelines require an account and are not agent-indexed.',
+      ]
+    );
+  }
+  if (path === '/explore') return renderExplore(source);
+  if (path === '/hobbies') return renderHobbyIndex(source);
+  if (path === '/experiences') return renderExperienceIndex(source);
+  if (path === '/journeys') return renderJourneyIndex(source);
+  if (path === '/bucket-lists') return renderBucketListIndex(source);
+  if (path === '/blog') return renderBlogIndex(source);
+
+  const staticPage = STATIC_PAGES[path];
+  if (staticPage) return page(staticPage.title, source, staticPage.summary);
+
+  const categoryMatch = path.match(/^\/hobbies\/category\/([^/]+)$/);
+  if (categoryMatch) return renderHobbyCategory(categoryMatch[1]!, source);
+
+  const hobbyMatch = path.match(/^\/hobbies\/([^/]+)$/);
+  if (hobbyMatch) return renderHobby(hobbyMatch[1]!, source);
+
+  const experienceMatch = path.match(/^\/experiences\/([^/]+)$/);
+  if (experienceMatch) return renderExperience(experienceMatch[1]!, source);
+
+  const journeyMatch = path.match(/^\/journeys\/([^/]+)$/);
+  if (journeyMatch) return renderJourney(journeyMatch[1]!, source);
+
+  const bucketListMatch = path.match(/^\/bucket-lists\/([^/]+)$/);
+  if (bucketListMatch) return renderBucketList(bucketListMatch[1]!, source);
+
+  const blogMatch = path.match(/^\/blog\/([^/]+)$/);
+  if (blogMatch) return renderArticle(blogMatch[1]!, source);
+
+  const profileMatch = path.match(/^\/u\/([^/]+)$/);
+  if (profileMatch) return renderPublicProfile(profileMatch[1]!, source);
+
+  return null;
+}
+
+async function renderExplore(source: string) {
+  try {
+    const rows = await db
+      .select({
+        title: timelines.title,
+        slug: timelines.slug,
+        username: users.username,
+      })
+      .from(timelines)
+      .leftJoin(users, eq(timelines.userId, users.id))
+      .where(eq(timelines.visibility, 'PUBLIC'))
+      .orderBy(desc(timelines.updatedAt))
+      .limit(100);
+    return page(
+      'Explore public hobby timelines',
+      source,
+      'Recent opt-in public timelines from the Significant Hobbies community.',
+      rows.map((row) => {
+        const href =
+          row.username && row.slug
+            ? `${SITE_URL}/u/${encodeURIComponent(row.username)}/${encodeURIComponent(row.slug)}`
+            : null;
+        const title = plain(row.title ?? 'Untitled timeline');
+        return href ? `[${title}](${href})` : title;
+      })
+    );
+  } catch {
+    return page(
+      'Explore public hobby timelines',
+      source,
+      'Recent opt-in public timelines. Live entries are temporarily unavailable.'
+    );
+  }
+}
+
+function renderHobbyIndex(source: string) {
+  const sections = HOBBY_CATEGORIES.map(
+    (category) =>
+      `## ${category.emoji} ${category.name}\n\n${category.hobbies
+        .map((hobby) => `- [${hobby}](${SITE_URL}/hobbies/${slugify(hobby)})`)
+        .join('\n')}`
+  );
+  return page(
+    'Hobby directory',
+    source,
+    `${HOBBY_CATEGORIES.reduce((sum, category) => sum + category.hobbies.length, 0)} hobbies across ${HOBBY_CATEGORIES.length} categories.`,
+    sections,
+    false
+  );
+}
+
+function renderHobbyCategory(slug: string, source: string) {
+  const category = HOBBY_CATEGORIES.find((item) => slugify(item.name) === slug);
+  if (!category) return null;
+  return page(
+    `${category.name} hobbies`,
+    source,
+    `Browse ${category.hobbies.length} ${category.name.toLowerCase()} hobbies.`,
+    category.hobbies.map((hobby) => `[${hobby}](${SITE_URL}/hobbies/${slugify(hobby)})`)
+  );
+}
+
+function renderHobby(slug: string, source: string) {
+  const hobby = HOBBY_CATEGORIES.flatMap((category) => category.hobbies).find(
+    (item) => slugify(item) === slug
+  );
+  if (!hobby) return null;
+  const category = getCategoryForHobby(hobby);
+  const roadmap = getRoadmapForHobby(hobby);
+  const resources = getResourcesForHobby(hobby);
+  const related = getRelatedHobbies(hobby);
+  const sections = [
+    `## A path from today to three months\n\n${roadmap.steps
+      .map((step) => `### ${step.horizon}: ${step.goal}\n\n${step.action}`)
+      .join('\n\n')}`,
+    resources.length
+      ? `## Resources\n\n${resources
+          .map(
+            (resource) =>
+              `- [${plain(resource.name)}](${resource.url}) — ${plain(resource.description)}`
+          )
+          .join('\n')}`
+      : '',
+    related.length
+      ? `## Related hobbies\n\n${related
+          .map(
+            (item) =>
+              `- [${plain(item.name)}](${SITE_URL}/hobbies/${slugify(item.name)}) — ${plain(item.reason)}`
+          )
+          .join('\n')}`
+      : '',
+  ].filter(Boolean);
+  return page(
+    hobby,
+    source,
+    `${category?.name ?? 'Hobby'} pursuit with a practical starting roadmap and related directions.`,
+    sections,
+    false
+  );
+}
+
+function renderExperienceIndex(source: string) {
+  const sections = EXPERIENCE_ENTRIES.map((entry) => {
+    const label = `${entry.emoji} ${entry.title}`;
+    return entry.description
+      ? `[${label}](${SITE_URL}/experiences/${entry.slug}) — ${plain(entry.description)}`
+      : label;
+  });
+  return page(
+    'Experiences worth making room for',
+    source,
+    `${EXPERIENCE_ENTRIES.length} places, milestones, and ideas worth considering.`,
+    sections
+  );
+}
+
+function renderExperience(slug: string, source: string) {
+  const entry = findExperience(slug);
+  if (!entry?.description) return null;
+  const steps = firstSteps(entry);
+  const related = relatedExperiences(entry);
+  return page(
+    `${entry.emoji} ${entry.title}`,
+    source,
+    entry.description,
+    [
+      `## How to start\n\n${steps
+        .map((step) => `### ${step.emoji} ${step.title}\n\n${step.body}`)
+        .join('\n\n')}`,
+      `## Related experiences\n\n${related
+        .map((item) =>
+          item.description
+            ? `- [${item.emoji} ${item.title}](${SITE_URL}/experiences/${item.slug})`
+            : `- ${item.emoji} ${item.title}`
+        )
+        .join('\n')}`,
+    ],
+    false
+  );
+}
+
+function renderJourneyIndex(source: string) {
+  return page(
+    'Famous hobby journeys',
+    source,
+    `How hobbies changed across ${FAMOUS_JOURNEYS.length} remarkable lives.`,
+    FAMOUS_JOURNEYS.map(
+      (person) =>
+        `[${person.emoji} ${person.name}](${SITE_URL}/journeys/${person.slug}) — ${plain(person.knownFor)}`
+    )
+  );
+}
+
+function renderJourney(slug: string, source: string) {
+  const person = FAMOUS_JOURNEYS.find((item) => item.slug === slug);
+  if (!person) return null;
+  return page(
+    `${person.name}'s hobby journey`,
+    source,
+    person.knownFor,
+    person.phases.map(
+      (phase) => `## ${phase.label}\n\n${phase.hobbies.map((hobby) => `- ${hobby}`).join('\n')}`
+    ),
+    false
+  );
+}
+
+function renderBucketListIndex(source: string) {
+  return page(
+    'Verified public bucket lists',
+    source,
+    `${FAMOUS_BUCKET_LISTS.length} sourced lists from notable people.`,
+    FAMOUS_BUCKET_LISTS.map(
+      (list) =>
+        `[${list.emoji} ${list.name}](${SITE_URL}/bucket-lists/${list.slug}) — ${plain(list.knownFor)}`
+    )
+  );
+}
+
+function renderBucketList(slug: string, source: string) {
+  const list = getFamousBucketList(slug);
+  if (!list) return null;
+  const sections = [
+    ...list.items.map(
+      (item) =>
+        `## ${item.title}\n\n${plain(item.description)}\n\nStatus: ${item.status.replaceAll('_', ' ')}${
+          item.completedNote ? `\n\n${plain(item.completedNote)}` : ''
+        }`
+    ),
+    list.sources?.length
+      ? `## Sources\n\n${list.sources
+          .map((item) => `- [${plain(item.label)}](${item.url})`)
+          .join('\n')}`
+      : '',
+  ].filter(Boolean);
+  return page(`${list.name}'s bucket list`, source, list.knownFor, sections, false);
+}
+
+function renderBlogIndex(source: string) {
+  return page(
+    'Hobby journal',
+    source,
+    'Long-form writing about hobbies, identity, leisure, and living curiously.',
+    editorialArticles.map(
+      (article) =>
+        `[${article.title}](${SITE_URL}/blog/${article.slug}) — ${plain(article.excerpt)}`
+    )
+  );
+}
+
+function renderArticle(slug: string, source: string) {
+  const article = getEditorialArticle(slug);
+  if (!article) return null;
+  const content = article.content
+    .map((block) => {
+      if (block.type === 'heading') return `${'#'.repeat(block.level)} ${plain(block.text)}`;
+      if (block.type === 'paragraph') return plain(block.text);
+      if (block.type === 'list') return block.items.map((item) => `- ${plain(item)}`).join('\n');
+      if (block.type === 'callout') return `> ${block.emoji} ${plain(block.text)}`;
+      if (block.type === 'quote') {
+        return `> ${plain(block.text)}${block.attribution ? `\n>\n> — ${plain(block.attribution)}` : ''}`;
+      }
+      if (block.type === 'video')
+        return `[Video](${block.url})${block.caption ? ` — ${plain(block.caption)}` : ''}`;
+      return '---';
+    })
+    .join('\n\n');
+  return page(article.title, source, article.excerpt, [content], false);
+}
+
+async function renderPublicProfile(rawUsername: string, source: string) {
+  const username = decodeURIComponent(rawUsername);
+  try {
+    const user = await db.query.users.findFirst({
+      where: eq(users.username, username),
+      columns: { id: true, name: true, username: true, bio: true, website: true, creed: true },
+    });
+    if (!user?.username) return null;
+    const rows = await db
+      .select({ title: timelines.title, slug: timelines.slug, phases: timelines.phases })
+      .from(timelines)
+      .where(and(eq(timelines.userId, user.id), eq(timelines.visibility, 'PUBLIC')))
+      .orderBy(desc(timelines.updatedAt));
+    if (rows.length === 0) return null;
+    const sections = rows.map((row) => {
+      const phases = parseJSONColumn<Phase[]>(row.phases, [], `agent-profile:${user.id}`);
+      return `## ${plain(row.title ?? 'Untitled timeline')}\n\n${phases
+        .map(
+          (phase) =>
+            `### ${plain(phase.label)}\n\n${phase.hobbies.map((hobby) => `- ${plain(hobby.name)}`).join('\n')}`
+        )
+        .join('\n\n')}`;
+    });
+    const summary = [user.bio, user.creed]
+      .filter((value): value is string => Boolean(value))
+      .map(plain)
+      .join(' ');
+    return page(
+      user.name ? `${plain(user.name)} (@${user.username})` : `@${user.username}`,
+      source,
+      summary || 'An opt-in public Significant Hobbies profile.',
+      sections,
+      false
+    );
+  } catch {
+    return null;
+  }
+}
+
+function page(
+  title: string,
+  source: string,
+  summary: string,
+  items: string[] = [],
+  listItems = true
+) {
+  const content = items
+    .filter(Boolean)
+    .map((item) => (listItems ? `- ${item}` : item))
+    .join('\n\n');
+  return `# ${plain(title)}\n\n> Source: ${source}\n\n${plain(summary)}${content ? `\n\n${content}` : ''}\n`;
+}
+
+function plain(value: string) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function normalizePath(pathname: string) {
+  if (!pathname || pathname === '/') return '/';
+  return `/${pathname}`.replace(/\/{2,}/g, '/').replace(/\/+$/, '');
+}

--- a/src/lib/site-metadata.ts
+++ b/src/lib/site-metadata.ts
@@ -1,0 +1,3 @@
+export const SITE_URL = 'https://significanthobbies.com';
+export const DEFAULT_SOCIAL_IMAGE = `${SITE_URL}/opengraph-image`;
+export const BRAND_NAME = 'Significant Hobbies';

--- a/worker.mjs
+++ b/worker.mjs
@@ -14,6 +14,7 @@
 import openNext from './.open-next/worker.js';
 import { withTiming } from './timing.mjs';
 import { handleAgentEdge } from './agent-edge.mjs';
+import { handlePublicRouteMarkdown } from './agent-route-markdown.mjs';
 
 // Durable Objects must be re-exported from the entry that wrangler.toml
 // points at, otherwise the bindings can't resolve them at deploy time.
@@ -85,6 +86,26 @@ export default {
       if (agent) return agent;
     }
     try {
+      const markdown = await handlePublicRouteMarkdown(request, async (sourcePath) => {
+        const sourceUrl = new URL('/api/ai/markdown', request.url);
+        sourceUrl.searchParams.set('path', sourcePath);
+        const sourceResponse = await openNext.fetch(
+          new Request(sourceUrl, {
+            headers: {
+              Accept: 'text/markdown',
+              'x-fleet-markdown-source': '1',
+            },
+          }),
+          env,
+          ctx
+        );
+        if (!sourceResponse.ok) return null;
+        const contentType = sourceResponse.headers.get('content-type') || '';
+        if (!contentType.toLowerCase().includes('text/markdown')) return null;
+        return sourceResponse.text();
+      });
+      if (markdown) return markdown;
+
       if (request.method !== 'GET') {
         return openNext.fetch(request, env, ctx);
       }


### PR DESCRIPTION
Closes #34

## What changed
- serve canonical-source Markdown for every public sitemap family via Accept negotiation and .md alternates
- keep private and unlisted application routes outside the agent boundary
- align llms.txt and /api/ai with real same-origin Markdown surfaces
- fix canonical, title, social-image, and graceful-fallback gaps across representative public content families
- add full generated-sitemap regression coverage and an OpenSpec change

## Verification
- pnpm check
- pnpm typecheck
- pnpm test (29 files, 411 tests)
- pnpm build (604 static pages)
- pnpm cf:build
- openspec validate serve-public-route-markdown --strict
- local agent-ready audit: S tier, 100 score, 250/250 sampled routes readable, 2/2 catalog surfaces valid
- local SEO audit: 12 pages, 166 checks passed, 0 failed, 14 non-critical warnings

No deployment performed.