### PR TITLE
Remove nested main landmarks across public routes

### DIFF
--- a/e2e/content-flywheel.spec.ts
+++ b/e2e/content-flywheel.spec.ts
@@ -71,7 +71,7 @@ test.describe('Significant content discovery routes', () => {
           }
         `,
       });
-      await expect(page.locator('main#main')).toHaveCount(1);
+      await expect(page.locator('main')).toHaveCount(1);
       await expect(page.locator('main#main h1')).toHaveCount(1);
       await expect(page.getByRole('navigation')).toBeVisible();
       await expect(page.getByRole('contentinfo')).toBeVisible();

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function AboutPage() {
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <div className="mx-auto max-w-3xl px-4 py-12">
       {/* Header */}
       <div className="relative mb-10 overflow-hidden rounded-3xl border border-border/60">
         <GridBackground variant="dots" size={22} />
@@ -64,6 +64,6 @@ export default function AboutPage() {
           </p>
         </SpotlightCard>
       </FadeIn>
-    </main>
+    </div>
   );
 }

--- a/src/app/bucket-list-before-30/page.tsx
+++ b/src/app/bucket-list-before-30/page.tsx
@@ -67,7 +67,7 @@ const faqSchema = {
 
 export default function BucketListBefore30Page() {
   return (
-    <main className="bg-card">
+    <div className="bg-card">
       <JsonLd data={faqSchema} />
 
       {/* ── Hero ─────────────────────────────────────────────────── */}
@@ -210,6 +210,6 @@ export default function BucketListBefore30Page() {
           </div>
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/app/bucket-list-before-50/page.tsx
+++ b/src/app/bucket-list-before-50/page.tsx
@@ -67,7 +67,7 @@ const faqSchema = {
 
 export default function BucketListBefore50Page() {
   return (
-    <main className="bg-card">
+    <div className="bg-card">
       <JsonLd data={faqSchema} />
 
       {/* ── Hero ─────────────────────────────────────────────────── */}
@@ -213,6 +213,6 @@ export default function BucketListBefore50Page() {
           </div>
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/app/bucket-list-ideas/page.tsx
+++ b/src/app/bucket-list-ideas/page.tsx
@@ -65,7 +65,7 @@ export default function BucketListIdeasPage() {
   );
 
   return (
-    <main className="bg-card">
+    <div className="bg-card">
       {/* ── Hero ─────────────────────────────────────────────────── */}
       <section className="relative bg-card pt-16 pb-10 px-4">
         <GridBackground />
@@ -223,6 +223,6 @@ export default function BucketListIdeasPage() {
           </div>
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/app/bucket-lists/[slug]/page.tsx
+++ b/src/app/bucket-lists/[slug]/page.tsx
@@ -83,7 +83,7 @@ export default async function FamousBucketListPage({ params }: Props) {
   };
 
   return (
-    <main className="bg-card">
+    <div className="bg-card">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
@@ -304,6 +304,6 @@ export default async function FamousBucketListPage({ params }: Props) {
           )}
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/app/bucket-lists/page.tsx
+++ b/src/app/bucket-lists/page.tsx
@@ -59,7 +59,7 @@ const TOTAL_PEOPLE = FAMOUS_BUCKET_LISTS.length;
 
 export default function BucketListsPage() {
   return (
-    <main className="bg-card">
+    <div className="bg-card">
       {/* ── Hero ─────────────────────────────────────────────────────────── */}
       <section className="relative bg-card pt-20 pb-16 px-4">
         <GridBackground />
@@ -286,6 +286,6 @@ export default function BucketListsPage() {
           </div>
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
 
 export default function ChangelogPage() {
   return (
-    <main id="main" className="mx-auto w-full max-w-3xl px-5 py-14 sm:py-20">
+    <div className="mx-auto w-full max-w-3xl px-5 py-14 sm:py-20">
       <header className="max-w-2xl">
         <Link
           href="/"
@@ -97,6 +97,6 @@ export default function ChangelogPage() {
           </li>
         ))}
       </ol>
-    </main>
+    </div>
   );
 }

--- a/src/app/get-started/get-started-client.tsx
+++ b/src/app/get-started/get-started-client.tsx
@@ -100,7 +100,7 @@ export function GetStartedClient() {
   }, []);
 
   return (
-    <main className="min-h-screen bg-card/40">
+    <div className="min-h-screen bg-card/40">
       {/* Hero */}
       <section className="relative overflow-hidden mx-auto max-w-2xl px-4 pt-20 pb-12 text-center">
         <GridBackground />
@@ -281,6 +281,6 @@ export function GetStartedClient() {
           ))}
         </StaggerContainer>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/app/hobbies/random/page.tsx
+++ b/src/app/hobbies/random/page.tsx
@@ -26,13 +26,13 @@ export default function RandomHobby() {
   }, []);
 
   return (
-    <main className="relative flex min-h-screen items-center justify-center overflow-hidden p-8">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden p-8">
       <GradientMesh />
       <FadeIn className="relative" delay={0.1}>
         <SpotlightCard className="rounded-2xl shadow-soft" innerClassName="p-12 text-center">
           <p className="font-mono text-sm text-muted-foreground">{msg}</p>
         </SpotlightCard>
       </FadeIn>
-    </main>
+    </div>
   );
 }

--- a/src/app/how-to-make-a-bucket-list/page.tsx
+++ b/src/app/how-to-make-a-bucket-list/page.tsx
@@ -97,7 +97,7 @@ const faqSchema = {
 
 export default function HowToMakeABucketListPage() {
   return (
-    <main className="bg-card">
+    <div className="bg-card">
       <JsonLd data={faqSchema} />
 
       {/* ── Hero ─────────────────────────────────────────────────── */}
@@ -240,6 +240,6 @@ export default function HowToMakeABucketListPage() {
           </SpotlightCard>
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/app/manifesto/page.tsx
+++ b/src/app/manifesto/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function ManifestoPage() {
   return (
-    <main className="relative mx-auto max-w-2xl px-4 py-16 sm:py-24">
+    <div className="relative mx-auto max-w-2xl px-4 py-16 sm:py-24">
       <GridBackground variant="dots" size={22} />
       <div className="relative">
         <Link href="/" className="text-sm text-muted-foreground hover:text-foreground">
@@ -134,6 +134,6 @@ export default function ManifestoPage() {
           </div>
         </article>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,7 +4,7 @@ export const metadata = { title: 'Not found — Significant Hobbies' };
 
 export default function NotFound() {
   return (
-    <main className="mx-auto max-w-md px-4 py-24 text-center text-foreground">
+    <div className="mx-auto max-w-md px-4 py-24 text-center text-foreground">
       <p className="font-mono text-sm text-muted-foreground">404</p>
       <h1 className="mt-3 text-3xl font-bold tracking-tight text-foreground">Not found</h1>
       <p className="mt-3 text-sm text-muted-foreground">
@@ -21,6 +21,6 @@ export default function NotFound() {
           About
         </Link>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <main className="relative mx-auto max-w-3xl px-4 py-12 text-sm leading-7 text-foreground">
+    <div className="relative mx-auto max-w-3xl px-4 py-12 text-sm leading-7 text-foreground">
       <GridBackground variant="dots" size={22} />
       <FadeIn className="relative">
         <Link href="/" className="text-xs text-muted-foreground hover:underline">
@@ -60,6 +60,6 @@ export default function PrivacyPage() {
           </p>
         </SpotlightCard>
       </FadeIn>
-    </main>
+    </div>
   );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
 
 export default function TermsPage() {
   return (
-    <main className="relative mx-auto max-w-3xl px-4 py-12 text-sm leading-7 text-foreground">
+    <div className="relative mx-auto max-w-3xl px-4 py-12 text-sm leading-7 text-foreground">
       <GridBackground variant="dots" size={22} />
       <FadeIn className="relative">
         <Link href="/" className="text-xs text-muted-foreground hover:underline">
@@ -50,6 +50,6 @@ export default function TermsPage() {
           </p>
         </SpotlightCard>
       </FadeIn>
-    </main>
+    </div>
   );
 }

--- a/src/app/timelines/recent/page.tsx
+++ b/src/app/timelines/recent/page.tsx
@@ -47,7 +47,7 @@ export default async function RecentTimelinesPage() {
     .limit(40);
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <div className="mx-auto max-w-3xl px-4 py-12">
       {/* Header with grid background + fade-in */}
       <div className="relative mb-2">
         <GridBackground />
@@ -119,6 +119,6 @@ export default async function RecentTimelinesPage() {
           })}
         </StaggerContainer>
       )}
-    </main>
+    </div>
   );
 }

--- a/src/app/travel-bucket-list/page.tsx
+++ b/src/app/travel-bucket-list/page.tsx
@@ -133,7 +133,7 @@ export default function TravelBucketListPage() {
   const totalDestinations = REGIONS.reduce((sum, r) => sum + r.items.length, 0);
 
   return (
-    <main className="bg-card">
+    <div className="bg-card">
       <JsonLd data={faqSchema} />
 
       {/* ── Hero ─────────────────────────────────────────────────── */}
@@ -304,6 +304,6 @@ export default function TravelBucketListPage() {
           </div>
         </div>
       </section>
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace route-level main elements with neutral wrappers under the shared RouteChrome main
- remove the duplicate main id on the changelog route
- tighten the content-flywheel accessibility check to count every main landmark

## Validation
- biome check on all 17 touched files
- pnpm typecheck
- Playwright desktop: content-flywheel, life-in-weeks, and experiences (21 passed)
- repository search confirms no route-level main elements remain
- git diff --check

Progresses #33