### PR TITLE
Remove the landing page LCP delay

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -5,7 +5,7 @@
 > Update this file when durable current or shipped product truth changes. Do
 > not let deploy-version snapshots accumulate here — put those in the archive.
 
-Last updated: 2026-07-29
+Last updated: 2026-07-31
 
 ## Why / What
 
@@ -21,6 +21,10 @@ is the bridge between daily practice and life aspirations.
 
 ## Timeline
 
+- **2026-07-31:** Removed the anonymous landing page's intentional idle-time
+  LCP delay and late font swap. Production-equivalent mobile Lighthouse
+  improved from 92 / 3.31s LCP to 99 / 1.97s LCP across three-run profiles,
+  with zero CLS; production deployment remains manual.
 - **2026-07-29:** Added an owned `/changelog` with verified shipped outcomes
   and direct GitHub Roadmap and Source links.
 - **2026-07-13:** Merged the Significant Content flywheel after strict OpenSpec,

--- a/landing-astro/src/layouts/Layout.astro
+++ b/landing-astro/src/layouts/Layout.astro
@@ -158,11 +158,11 @@ const OG_IMAGE = `${SITE_URL}/opengraph-image`;
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400..800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400..800&display=optional"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
     />
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@400..800&display=swap" /></noscript>
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@400..800&display=optional" /></noscript>
   </head>
   <body class="antialiased lcp-pending">
     <div id="lcp-shell" aria-hidden="true">
@@ -186,20 +186,15 @@ const OG_IMAGE = `${SITE_URL}/opengraph-image`;
           location.replace('/dashboard');
         }
       })();
-      // Keep #lcp-shell as LCP until the browser is idle — rAF was too early
-      // and Lighthouse still attributed paint to the Tailwind-blocked hero.
+      // Hand off to the fully styled static hero on the next paint. Waiting
+      // for idle kept the duplicate shell visible for several seconds on
+      // throttled devices and turned that intentional delay into the LCP.
       (function () {
         var drop = function () {
           document.getElementById('lcp-shell')?.remove();
           document.body.classList.remove('lcp-pending');
         };
-        if ('requestIdleCallback' in window) {
-          requestIdleCallback(drop, { timeout: 4000 });
-        } else {
-          window.addEventListener('load', function () {
-            setTimeout(drop, 2000);
-          });
-        }
+        requestAnimationFrame(drop);
       })();
     </script>
     <slot />


### PR DESCRIPTION
## What changed

- hand the duplicate critical landing shell over to the fully styled hero on the next animation frame
- stop the late Archivo webfont swap from creating a second LCP candidate on slow links

## Why

The landing shell was intentionally retained until an idle callback or a two-second post-load timeout. Under mobile throttling, that wait became the LCP delay. A late font repaint then made the result variable.

## Impact

Production-equivalent, three-run PSI profiles improved:

- mobile performance: 92 p75 to 99 p75
- mobile LCP: 3.31s p75 to 1.97s p75
- mobile CLS: 0.033 to 0
- desktop performance remains 100

No thresholds were changed and this PR does not deploy anything.

## Validation

- pnpm cf:build
- pnpm lint
- pnpm typecheck
- pnpm test: 411 tests passed
- recorded psi-swarm production-equivalent before and after runs with HTML reports

Closes #38