### PR TITLE
Fix public profile Share hydration

### DIFF
--- a/src/components/profile-share-button.test.tsx
+++ b/src/components/profile-share-button.test.tsx
@@ -1,0 +1,32 @@
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ProfileShareButton } from './profile-share-button';
+
+const originalShare = navigator.share;
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'share', {
+    configurable: true,
+    value: originalShare,
+  });
+});
+
+function renderWithShare(value: typeof navigator.share | undefined) {
+  Object.defineProperty(navigator, 'share', {
+    configurable: true,
+    value,
+  });
+
+  return renderToString(<ProfileShareButton username="avery" displayName="Avery Rowan" />);
+}
+
+describe('ProfileShareButton', () => {
+  it('renders the same markup regardless of Web Share support', () => {
+    const clipboardMarkup = renderWithShare(undefined);
+    const nativeShareMarkup = renderWithShare(vi.fn());
+
+    expect(nativeShareMarkup).toBe(clipboardMarkup);
+    expect(nativeShareMarkup).toContain('lucide-share');
+  });
+});

--- a/src/components/profile-share-button.tsx
+++ b/src/components/profile-share-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Link2, Share2 } from 'lucide-react';
+import { Share2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '~/components/ui/button';
@@ -19,8 +19,6 @@ interface ProfileShareButtonProps {
  * the link.
  */
 export function ProfileShareButton({ username, displayName }: ProfileShareButtonProps) {
-  const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
-
   async function copyLink() {
     try {
       await navigator.clipboard.writeText(window.location.href);
@@ -31,7 +29,7 @@ export function ProfileShareButton({ username, displayName }: ProfileShareButton
   }
 
   async function handleShare() {
-    if (!canNativeShare) {
+    if (typeof navigator.share !== 'function') {
       await copyLink();
       return;
     }
@@ -56,7 +54,7 @@ export function ProfileShareButton({ username, displayName }: ProfileShareButton
       className="gap-1.5"
       aria-label={`Share @${username}'s profile`}
     >
-      {canNativeShare ? <Share2 className="h-3.5 w-3.5" /> : <Link2 className="h-3.5 w-3.5" />}
+      <Share2 className="h-3.5 w-3.5" />
       Share
     </Button>
   );


### PR DESCRIPTION
Closes #48

## Summary
- render one deterministic Share icon on the server and client
- defer Web Share capability detection until click time
- preserve native sharing and clipboard fallback
- add a server-markup regression test for both capability states

## Validation
- pnpm check
- pnpm test (36 files, 433 tests)
- pnpm typecheck
- fresh-browser profile checks at 390 and 1440 px: 200, zero page/console errors, no overflow

No dependency, schema, migration, deployment, authentication, or production-configuration change.