### PR TITLE
Prevent invalid profile timestamps from crashing sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,6 +7,7 @@ import { FAMOUS_BUCKET_LISTS } from '~/lib/famous-bucket-lists';
 import { FAMOUS_JOURNEYS } from '~/lib/famous-journeys';
 import { PAGED_EXPERIENCES } from '~/lib/experiences';
 import { HOBBY_CATEGORIES } from '~/lib/hobbies';
+import { sitemapLastModified } from '~/lib/sitemap-last-modified';
 import { db } from '~/server/db';
 
 // D1 is request-scoped under OpenNext. Generating this route at build time has
@@ -24,7 +25,10 @@ export const dynamic = 'force-dynamic';
  * Returns [] on failure: a database hiccup should degrade the sitemap, never
  * 500 it and lose the static entries with it.
  */
-async function publicProfileEntries(baseUrl: string): Promise<MetadataRoute.Sitemap> {
+async function publicProfileEntries(
+  baseUrl: string,
+  fallbackDate: Date
+): Promise<MetadataRoute.Sitemap> {
   try {
     const rows = await db
       .select({
@@ -43,7 +47,7 @@ async function publicProfileEntries(baseUrl: string): Promise<MetadataRoute.Site
         ? [
             {
               url: `${baseUrl}/u/${encodeURIComponent(row.username)}`,
-              lastModified: row.lastUpdated ? new Date(row.lastUpdated) : new Date(),
+              lastModified: sitemapLastModified(row.lastUpdated, fallbackDate),
               changeFrequency: 'weekly' as const,
               priority: 0.6,
             },
@@ -64,7 +68,7 @@ async function publicProfileEntries(baseUrl: string): Promise<MetadataRoute.Site
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://significanthobbies.com';
   const now = new Date();
-  const profilePages = await publicProfileEntries(baseUrl);
+  const profilePages = await publicProfileEntries(baseUrl, now);
 
   const categoryPages = [
     'creative',

--- a/src/lib/sitemap-last-modified.test.ts
+++ b/src/lib/sitemap-last-modified.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { sitemapLastModified } from './sitemap-last-modified';
+
+describe('sitemapLastModified', () => {
+  const fallback = new Date('2026-08-01T00:00:00.000Z');
+
+  it('preserves valid dates and parses epoch timestamps', () => {
+    const date = new Date('2026-07-31T12:00:00.000Z');
+
+    expect(sitemapLastModified(date, fallback)).toBe(date);
+    expect(sitemapLastModified(1_785_604_560, fallback).toISOString()).toBe(
+      '2026-08-01T17:16:00.000Z'
+    );
+    expect(sitemapLastModified('1785604560000', fallback).toISOString()).toBe(
+      '2026-08-01T17:16:00.000Z'
+    );
+  });
+
+  it('falls back when migrated values cannot produce a valid date', () => {
+    expect(sitemapLastModified(new Date('invalid'), fallback)).toBe(fallback);
+    expect(sitemapLastModified('not-a-date', fallback)).toBe(fallback);
+    expect(sitemapLastModified(null, fallback)).toBe(fallback);
+  });
+});

--- a/src/lib/sitemap-last-modified.ts
+++ b/src/lib/sitemap-last-modified.ts
@@ -1,0 +1,25 @@
+const EPOCH_MILLISECONDS_THRESHOLD = 10_000_000_000;
+
+export function sitemapLastModified(value: unknown, fallback: Date): Date {
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value : fallback;
+  }
+
+  if (typeof value === 'number') {
+    return numericDate(value, fallback);
+  }
+
+  if (typeof value !== 'string' || value.trim() === '') return fallback;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numericDate(numeric, fallback);
+
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : fallback;
+}
+
+function numericDate(value: number, fallback: Date): Date {
+  if (!Number.isFinite(value)) return fallback;
+  const milliseconds = Math.abs(value) < EPOCH_MILLISECONDS_THRESHOLD ? value * 1000 : value;
+  const parsed = new Date(milliseconds);
+  return Number.isFinite(parsed.getTime()) ? parsed : fallback;
+}


### PR DESCRIPTION
## Summary
- normalize public-profile sitemap timestamps before serialization
- accept valid dates plus epoch seconds and milliseconds
- fall back safely for malformed legacy values so static sitemap entries remain available
- add focused regression coverage

A live Worker tail captured `RangeError: Invalid time value` while serializing `/sitemap.xml`. This change prevents that invalid value from reaching `Date.toISOString()`.

## Validation
- `pnpm exec vitest run src/lib/sitemap-last-modified.test.ts src/lib/agent-route-markdown.test.ts` (9 passed)
- `pnpm test` (441 passed)
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec biome check src/app/sitemap.ts src/lib/sitemap-last-modified.ts src/lib/sitemap-last-modified.test.ts`
- `git diff --check`

Production deployment remains manual and is not part of this PR.

Closes #53