### PR TITLE
fix: harden local workspace release

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -31,7 +31,13 @@ is the bridge between daily practice and life aspirations.
   player with three upbeat choices, remembered selection, autoplay attempts,
   and an honest one-tap fallback when the browser blocks sound. The first
   possibility shelf is a balanced 18-item editorial selection rather than the
-  travel-heavy start of the raw catalog. Production deployment remains manual.
+  travel-heavy start of the raw catalog. Live More now draws its internal
+  suggestions from that same 5,000+ path corpus. Local onboarding writes a
+  non-sensitive workspace marker so the production Worker can serve the local
+  dashboard at `/` before hydration while IndexedDB remains authoritative.
+  Local Daily greetings use the saved profile name. The standalone trace root
+  is pinned to this repository so the Cloudflare/OpenNext build remains
+  independently operable. Production deployment remains manual.
 
 - **2026-08-02:** Built the simplified post-onboarding private product locally:
   onboarded account or local `/` is the dashboard, signed-in incomplete accounts

--- a/e2e/daily.spec.ts
+++ b/e2e/daily.spec.ts
@@ -11,6 +11,9 @@ test.describe('Daily ritual & manifesto', () => {
     expect(page.url()).not.toContain('/login');
     await expect(page.getByLabel('Preview notice')).toHaveCount(0);
     await expect(page.locator('#daily-journal-entry')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Good (morning|evening), Local\./ })
+    ).toBeVisible();
   });
 
   test('/daily has no serious accessibility violations', async ({ page }) => {

--- a/e2e/fixtures/local-onboarding.ts
+++ b/e2e/fixtures/local-onboarding.ts
@@ -2,6 +2,14 @@ import type { Page } from '@playwright/test';
 
 export async function completeLocalOnboarding(page: Page) {
   await page.goto('/onboarding');
+  await page.context().addCookies([
+    {
+      name: 'sh_local_workspace',
+      value: '1',
+      url: new URL(page.url()).origin,
+      sameSite: 'Lax',
+    },
+  ]);
   await page.evaluate(async () => {
     const database = await new Promise<IDBDatabase>((resolve, reject) => {
       const request = indexedDB.open('significant-hobbies-local', 1);

--- a/e2e/guest-access.spec.ts
+++ b/e2e/guest-access.spec.ts
@@ -21,8 +21,9 @@ test.describe('private work is locally available without an account', () => {
 
   test('root becomes the local dashboard after onboarding', async ({ page }) => {
     await completeLocalOnboarding(page);
-    await page.goto('/');
+    const response = await page.goto('/');
     await expect(page).toHaveURL(/\/$/);
+    expect(await response?.text()).not.toContain('What will you do with the time you have?');
     await expect(page.getByRole('heading', { name: /Your dashboard/i })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Check in' })).toHaveAttribute('href', '/daily');
     if (!(await page.getByRole('link', { name: 'Daily', exact: true }).first().isVisible())) {

--- a/e2e/life-atlas.spec.ts
+++ b/e2e/life-atlas.spec.ts
@@ -34,6 +34,7 @@ test.describe('Life Atlas shell', () => {
     await expect(
       page.getByRole('heading', { name: /What do you still want to live/ })
     ).toBeVisible();
+    await expect(page.getByText('More than 5,000 possibilities')).toBeVisible();
     for (const name of [
       'Discover a life you have not thought of yet.',
       'Life Bingo',

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,11 @@ initOpenNextCloudflareForDev({ configPath: './wrangler.local.toml' });
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // This repository is independently deployable even though a Fleet lockfile
+  // exists above it. Without an explicit trace root, Next nests the standalone
+  // app under `.next/standalone/significanthobbies/`, while OpenNext expects
+  // `.next/standalone/.next/` and cannot find pages-manifest.json.
+  outputFileTracingRoot: process.cwd(),
   reactCompiler: true,
   experimental: {
     optimizePackageImports: ['lucide-react'],

--- a/src/app/local-workspace/page.tsx
+++ b/src/app/local-workspace/page.tsx
@@ -1,0 +1,16 @@
+import { LocalRootExperience } from '~/components/local-root-experience';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Dashboard — SignificantHobbies',
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Internal target for the Worker's signed-out local-workspace rewrite.
+ * The public URL remains `/`; IndexedDB is revalidated by LocalRootExperience.
+ */
+export default function LocalWorkspacePage() {
+  return <LocalRootExperience initialComplete />;
+}

--- a/src/app/onboarding/onboarding-flow.tsx
+++ b/src/app/onboarding/onboarding-flow.tsx
@@ -23,6 +23,7 @@ import { StorageModeProvider, StorageModeStatus } from '~/components/storage-mod
 import { completeOnboarding } from '~/lib/actions/onboarding';
 import { browserRecordAdapter, readLocalRecord, writeLocalRecord } from '~/lib/local-record-store';
 import { createLocalTrajectory } from '~/lib/local-trajectory';
+import { syncLocalWorkspaceCookie } from '~/lib/local-workspace-cookie';
 import type { StorageMode } from '~/lib/storage-mode';
 
 type Possibility = {
@@ -294,6 +295,7 @@ export function OnboardingFlow({
       }
       await writeLocalRecord(adapter, 'daily:state', 'daily', daily);
       await createLocalTrajectory(trajectory, adapter).catch(() => undefined);
+      syncLocalWorkspaceCookie(true);
     }
     router.push('/');
     router.refresh();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { and, desc, eq } from 'drizzle-orm';
 import { ArrowRight, Check, Circle, Clock3, ListChecks, NotebookPen } from 'lucide-react';
 import Link from 'next/link';
+import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { LocalRootExperience } from '~/components/local-root-experience';
@@ -8,6 +9,7 @@ import { TimezoneSync } from '~/components/timezone-sync';
 import { bucketListItems, habitLogs, habits, journalEntries, users } from '~/db/schema';
 import { dayKeyIn } from '~/lib/day';
 import { lifeInWeeksFromDate, parseBirthDate } from '~/lib/life-in-weeks';
+import { LOCAL_WORKSPACE_COOKIE } from '~/lib/local-workspace-cookie';
 import { getServerAuthSession } from '~/server/auth';
 import { db } from '~/server/db';
 
@@ -20,7 +22,14 @@ export const metadata = {
 
 export default async function HomePage() {
   const session = await getServerAuthSession();
-  if (!session?.user) return <LocalRootExperience />;
+  if (!session?.user) {
+    const cookieStore = await cookies();
+    return (
+      <LocalRootExperience
+        initialComplete={cookieStore.get(LOCAL_WORKSPACE_COOKIE)?.value === '1'}
+      />
+    );
+  }
 
   const me = await db.query.users.findFirst({
     where: eq(users.id, session.user.id),

--- a/src/components/live-more-discovery.tsx
+++ b/src/components/live-more-discovery.tsx
@@ -113,14 +113,14 @@ export function LiveMoreDiscovery({
               <Compass className="size-6" />
             </div>
             <p className="mt-7 text-sm font-bold uppercase tracking-[0.2em] text-[#a8dc91]">
-              More than 300 possibilities
+              More than 5,000 possibilities
             </p>
             <h2 className="mt-3 max-w-xl font-serif text-4xl leading-[1.02] sm:text-5xl">
               Discover a life you have not thought of yet.
             </h2>
             <p className="mt-5 max-w-lg leading-relaxed text-white/68">
-              Three directions, drawn from more than 300 real possibilities. Save what calls you,
-              set aside what does not, or turn one into a small first step.
+              Three directions, drawn from more than 5,000 real paths. Save what calls you, set
+              aside what does not, or turn one into a small first step.
             </p>
           </div>
           <div className="mt-8 flex flex-wrap gap-3">
@@ -135,7 +135,7 @@ export function LiveMoreDiscovery({
               href="/experiences"
               className="inline-flex min-h-11 items-center gap-2 border-b-2 border-[#f7e957] font-bold"
             >
-              Browse all <ArrowRight className="size-4" />
+              Browse curated experiences <ArrowRight className="size-4" />
             </Link>
           </div>
           <div aria-live="polite" className="mt-4 min-h-6 text-sm text-white/80">

--- a/src/components/local-daily-ritual.tsx
+++ b/src/components/local-daily-ritual.tsx
@@ -42,21 +42,36 @@ interface LocalDailyState {
   logs: LocalHabitLog[];
   journals: LocalJournal[];
 }
+interface LocalProfile {
+  name?: string;
+}
 
 const EMPTY: LocalDailyState = { habits: [], logs: [], journals: [] };
 
 export function LocalDailyRitual({ today, isMorning }: { today: string; isMorning: boolean }) {
   const [state, setState] = useState<LocalDailyState>(EMPTY);
+  const [profile, setProfile] = useState<LocalProfile>({});
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    readLocalRecord(
-      browserRecordAdapter(),
-      'daily:state',
-      'daily',
-      (value): value is LocalDailyState => !!value && typeof value === 'object' && 'habits' in value
-    ).then((stored) => {
+    const adapter = browserRecordAdapter();
+    Promise.all([
+      readLocalRecord(
+        adapter,
+        'daily:state',
+        'daily',
+        (value): value is LocalDailyState =>
+          !!value && typeof value === 'object' && 'habits' in value
+      ),
+      readLocalRecord(
+        adapter,
+        'onboarding:profile',
+        'onboarding',
+        (value): value is LocalProfile => !!value && typeof value === 'object'
+      ),
+    ]).then(([stored, storedProfile]) => {
       setState(stored ?? EMPTY);
+      setProfile(storedProfile ?? {});
       setLoaded(true);
     });
   }, []);
@@ -196,7 +211,7 @@ export function LocalDailyRitual({ today, isMorning }: { today: string; isMornin
         <StorageModeStatus />
       </div>
       <DailyRitual
-        firstName="there"
+        firstName={profile.name?.trim().split(/\s+/)[0] || 'there'}
         today={today}
         isMorning={isMorning}
         weeksRemaining={null}

--- a/src/components/local-onboarding-gate.tsx
+++ b/src/components/local-onboarding-gate.tsx
@@ -4,9 +4,10 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { browserRecordAdapter, readLocalRecord } from '~/lib/local-record-store';
+import { syncLocalWorkspaceCookie } from '~/lib/local-workspace-cookie';
 
-export function useLocalOnboardingComplete(): boolean | null {
-  const [complete, setComplete] = useState<boolean | null>(null);
+export function useLocalOnboardingComplete(initialComplete: boolean | null = null): boolean | null {
+  const [complete, setComplete] = useState<boolean | null>(initialComplete);
   useEffect(() => {
     readLocalRecord(
       browserRecordAdapter(),
@@ -14,8 +15,15 @@ export function useLocalOnboardingComplete(): boolean | null {
       'onboarding',
       (value): value is Record<string, unknown> => Boolean(value && typeof value === 'object')
     )
-      .then((profile) => setComplete(Boolean(profile)))
-      .catch(() => setComplete(false));
+      .then((profile) => {
+        const nextComplete = Boolean(profile);
+        syncLocalWorkspaceCookie(nextComplete);
+        setComplete(nextComplete);
+      })
+      .catch(() => {
+        syncLocalWorkspaceCookie(false);
+        setComplete(false);
+      });
   }, []);
   return complete;
 }

--- a/src/components/local-root-experience.tsx
+++ b/src/components/local-root-experience.tsx
@@ -4,8 +4,8 @@ import { LocalWorkspaceHome } from '~/components/local-workspace-home';
 import { useLocalOnboardingComplete } from '~/components/local-onboarding-gate';
 import { PublicLanding, PublicLandingShell } from '~/components/public-landing';
 
-export function LocalRootExperience() {
-  const complete = useLocalOnboardingComplete();
+export function LocalRootExperience({ initialComplete = false }: { initialComplete?: boolean }) {
+  const complete = useLocalOnboardingComplete(initialComplete);
   if (complete === null) return <PublicLandingShell />;
   if (complete) return <LocalWorkspaceHome title="Your dashboard" />;
 

--- a/src/components/local-workspace-home.tsx
+++ b/src/components/local-workspace-home.tsx
@@ -70,7 +70,11 @@ export function LocalWorkspaceHome({ title = 'Your dashboard' }: { title?: strin
                 </div>
                 <h1 className="mt-5 font-serif text-5xl font-medium tracking-[-0.04em] sm:text-6xl">
                   <span className="sr-only">Your dashboard. </span>
-                  {title === 'Your dashboard' ? `Live it, ${firstName}.` : title}
+                  {title === 'Your dashboard'
+                    ? loaded
+                      ? `Live it, ${firstName}.`
+                      : 'Your dashboard'
+                    : title}
                 </h1>
                 <blockquote className="mt-5 max-w-2xl font-serif text-xl leading-snug text-[#3e3924] sm:text-2xl">
                   “{quote}”

--- a/src/lib/bucket-list-insights.test.ts
+++ b/src/lib/bucket-list-insights.test.ts
@@ -116,6 +116,10 @@ describe('getBucketListSuggestions', () => {
     expect(out.length).toBeGreaterThan(0);
   });
 
+  it('draws from the full possibility catalog used during onboarding', () => {
+    expect(getBucketListSuggestions([], 1_000, 0)).toHaveLength(1_000);
+  });
+
   it('respects the count argument', () => {
     expect(getBucketListSuggestions([], 3).length).toBeLessThanOrEqual(3);
     expect(getBucketListSuggestions([], 2).length).toBeLessThanOrEqual(2);

--- a/src/lib/bucket-list-insights.ts
+++ b/src/lib/bucket-list-insights.ts
@@ -1,9 +1,9 @@
-import { ALL_EXPERIENCES } from '~/lib/experiences';
 import {
   BUCKET_ITEM_CATEGORIES,
   type BucketItemCategory,
   FAMOUS_BUCKET_LISTS,
 } from '~/lib/famous-bucket-lists';
+import { getOnboardingPossibilities } from '~/lib/onboarding-possibilities';
 
 // ─── Personality Archetypes ───────────────────────────────────────────────────
 
@@ -192,15 +192,16 @@ type SuggestionItem = {
 };
 
 /**
- * Suggestions are drawn from the shared corpus rather than a private list.
+ * Suggestions are drawn from the same 5,000+ path corpus used by onboarding
+ * rather than a private list.
  *
  * This used to be 52 hand-written items — a near-duplicate of the 145 already
  * sitting in `/bucket-list-ideas`, which were unreachable because they lived
- * inside a page component. Users were being offered a third of the material
- * the product already owned, and any new idea had to be written twice to show
- * up in both places.
+ * inside a page component. Live More now shares the combined experience and
+ * hobby-path source so the product makes the same possibility promise before
+ * and after onboarding.
  */
-const SUGGESTION_POOL: SuggestionItem[] = ALL_EXPERIENCES;
+const SUGGESTION_POOL: SuggestionItem[] = getOnboardingPossibilities();
 
 // ─── Token-based title similarity ────────────────────────────────────────────
 

--- a/src/lib/experiences.test.ts
+++ b/src/lib/experiences.test.ts
@@ -14,6 +14,7 @@ import {
 } from './experiences';
 import { FAMOUS_BUCKET_LISTS } from './famous-bucket-lists';
 import { getBucketListSuggestions } from './bucket-list-insights';
+import { getOnboardingPossibilities } from './onboarding-possibilities';
 
 describe('experiences corpus', () => {
   it('covers all six categories with real content in each', () => {
@@ -110,8 +111,8 @@ describe('the suggestion engine reads the shared corpus', () => {
     expect(getBucketListSuggestions([], 8, 0)).toHaveLength(8);
   });
 
-  it('suggests only things that exist in the corpus', () => {
-    const corpus = new Set(ALL_EXPERIENCES.map((e) => e.title));
+  it('suggests only things that exist in the shared possibility corpus', () => {
+    const corpus = new Set(getOnboardingPossibilities().map((possibility) => possibility.title));
     for (const s of getBucketListSuggestions([], 50, 0)) {
       expect(corpus.has(s.title), `${s.title} should come from the corpus`).toBe(true);
     }

--- a/src/lib/local-workspace-cookie.ts
+++ b/src/lib/local-workspace-cookie.ts
@@ -1,0 +1,20 @@
+export const LOCAL_WORKSPACE_COOKIE = 'sh_local_workspace';
+
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Keep a non-sensitive hint beside the real IndexedDB workspace.
+ *
+ * The hint lets the Worker and the Next.js root choose the local dashboard
+ * before React hydrates. IndexedDB remains authoritative; this cookie contains
+ * no profile or journal data and is corrected after the client reads the
+ * onboarding record.
+ */
+export function syncLocalWorkspaceCookie(complete: boolean): void {
+  if (typeof document === 'undefined') return;
+  const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+  // biome-ignore lint/suspicious/noDocumentCookie: broad browser support is required for the Worker routing hint.
+  document.cookie = complete
+    ? `${LOCAL_WORKSPACE_COOKIE}=1; Path=/; Max-Age=${ONE_YEAR_IN_SECONDS}; SameSite=Lax${secure}`
+    : `${LOCAL_WORKSPACE_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax${secure}`;
+}

--- a/worker.mjs
+++ b/worker.mjs
@@ -71,11 +71,17 @@ function isCacheableDocumentPath(pathname) {
 // session in both prod (__Secure-) and dev variants so signed-in users
 // always see live SSR (e.g. redirect to /library).
 const AUTH_COOKIE_FRAGMENTS = ['session_token', 'session-token'];
+// Non-sensitive client hint; IndexedDB remains the local workspace authority.
+const LOCAL_WORKSPACE_COOKIE = 'sh_local_workspace=1';
 
 function hasAuthCookie(request) {
   const cookie = request.headers.get('cookie');
   if (!cookie) return false;
   return AUTH_COOKIE_FRAGMENTS.some((c) => cookie.includes(c));
+}
+
+function hasLocalWorkspaceCookie(request) {
+  return request.headers.get('cookie')?.includes(LOCAL_WORKSPACE_COOKIE) ?? false;
 }
 
 export default {
@@ -117,6 +123,15 @@ export default {
       // going to be redirected by middleware to /library or /dashboard.
       if (hasAuthCookie(request)) {
         return openNext.fetch(request, env, ctx);
+      }
+      if (url.pathname === '/' && hasLocalWorkspaceCookie(request)) {
+        // OpenNext normalizes request cookies and query hints before rendering
+        // `/`. Rewrite to the internal local-workspace entry instead; the
+        // browser remains at `/`, and IndexedDB is still verified after
+        // hydration.
+        url.pathname = '/local-workspace';
+        url.search = '';
+        return openNext.fetch(new Request(url, request), env, ctx);
       }
 
       // Short-circuit: the Astro landing is overlaid into


### PR DESCRIPTION
## Summary
- serve the local dashboard at `/` before hydration without moving private data out of IndexedDB
- personalize local Daily and expand Live More discovery to the shared 5,000+ possibility corpus
- pin Next standalone tracing for reliable OpenNext/Cloudflare builds

## Verification
- `pnpm test` (471 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm docs:check`
- `pnpm cf:build`
- targeted guest/local E2E on desktop and mobile (64 journeys)
- authenticated E2E (20 journeys)
- production Worker dry run for anonymous and local-workspace `/`

No schema changes or migrations.