### PR TITLE
fix: repair landing typography response

### DIFF
--- a/landing-astro/src/layouts/Layout.astro
+++ b/landing-astro/src/layouts/Layout.astro
@@ -45,7 +45,7 @@ const OG_IMAGE = `${SITE_URL}/opengraph-image`;
       #lcp-shell .lcp-wordmark {
         margin: 0;
         color: oklch(0.98 0.005 90);
-        font-family: 'Archivo', Arial, sans-serif;
+        font-family: 'Geist', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
         font-size: 0.95rem;
         font-weight: 650;
         letter-spacing: -0.01em;
@@ -58,11 +58,11 @@ const OG_IMAGE = `${SITE_URL}/opengraph-image`;
       #lcp-shell .lcp-title {
         margin: 0;
         color: oklch(0.99 0.004 90);
-        font-family: 'Archivo', Arial, sans-serif;
+        font-family: 'Fraunces', Georgia, Cambria, 'Times New Roman', serif;
         font-size: clamp(3rem, 6.8vw, 6rem);
-        font-weight: 720;
-        line-height: 0.98;
-        letter-spacing: -0.035em;
+        font-weight: 500;
+        line-height: 0.96;
+        letter-spacing: -0.03em;
       }
       #lcp-shell .lcp-line {
         display: block;
@@ -71,7 +71,7 @@ const OG_IMAGE = `${SITE_URL}/opengraph-image`;
         margin: 0;
         align-self: flex-end;
         color: oklch(0.92 0.018 88);
-        font-family: 'Archivo', Arial, sans-serif;
+        font-family: 'Geist', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
         font-size: 0.875rem;
       }
       @media (max-width: 48rem) {
@@ -158,11 +158,11 @@ const OG_IMAGE = `${SITE_URL}/opengraph-image`;
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400..800&display=optional"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400..700&family=Geist:wght@400..700&display=optional"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
     />
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@400..800&display=optional" /></noscript>
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400..700&family=Geist:wght@400..700&display=optional" /></noscript>
   </head>
   <body class="antialiased lcp-pending">
     <div id="lcp-shell" aria-hidden="true">

--- a/landing-astro/src/styles/landing.css
+++ b/landing-astro/src/styles/landing.css
@@ -21,9 +21,9 @@
   --color-input: var(--input);
   --color-ring: var(--ring);
   --color-growth: var(--growth);
-  --font-sans: var(--font-archivo);
-  --font-serif: var(--font-archivo);
-  --font-display: var(--font-archivo);
+  --font-sans: var(--font-geist);
+  --font-serif: var(--font-fraunces);
+  --font-display: var(--font-fraunces);
 }
 
 :root {
@@ -54,21 +54,24 @@
   --ring: oklch(0.39 0.1 72);
   /* growth — sage green (practice / stamps / progress) */
   --growth: oklch(0.72 0.13 150);
-  /* One committed family: cinematic display weights, legible text weights. */
-  --font-archivo: 'Archivo', 'Arial Narrow', Arial, sans-serif;
+  /* Match the product: reflective landmarks + a quiet, legible workhorse. */
+  --font-fraunces: 'Fraunces', Georgia, Cambria, 'Times New Roman', serif;
+  --font-geist: 'Geist', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 body {
   margin: 0;
-  font-family: var(--font-archivo);
+  font-family: var(--font-geist);
   background: var(--background);
   color: var(--foreground);
+  font-synthesis: none;
 }
 
-/* Display headings share the landing's single-family typographic system. */
+/* Display headings carry the reflective Life Atlas voice used in the app. */
 h1, h2, h3 {
-  font-family: var(--font-archivo);
-  letter-spacing: -0.015em;
+  font-family: var(--font-fraunces);
+  font-optical-sizing: auto;
+  letter-spacing: -0.02em;
   text-wrap: balance;
 }
 
@@ -126,7 +129,7 @@ h1, h2, h3 {
 .cinematic-hero__wordmark {
   margin: 0;
   color: oklch(0.98 0.005 90);
-  font-family: var(--font-archivo);
+  font-family: var(--font-geist);
   font-size: 0.95rem;
   font-weight: 650;
   letter-spacing: -0.01em;
@@ -141,11 +144,12 @@ h1, h2, h3 {
 .cinematic-hero h1 {
   margin: 0;
   color: oklch(0.99 0.004 90);
-  font-family: var(--font-archivo);
+  font-family: var(--font-fraunces);
+  font-optical-sizing: auto;
   font-size: clamp(3rem, 6.8vw, 6rem);
-  font-weight: 720;
-  letter-spacing: -0.035em;
-  line-height: 0.98;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  line-height: 0.96;
   text-wrap: balance;
 }
 
@@ -157,7 +161,7 @@ h1, h2, h3 {
   max-width: 47ch;
   margin: clamp(1.5rem, 3vw, 2rem) 0 0;
   color: oklch(0.92 0.018 88);
-  font-family: var(--font-archivo);
+  font-family: var(--font-geist);
   font-size: clamp(1.05rem, 1.5vw, 1.25rem);
   line-height: 1.55;
   text-wrap: pretty;
@@ -173,7 +177,7 @@ h1, h2, h3 {
   border-radius: 999px;
   background: oklch(0.84 0.14 85);
   color: oklch(0.16 0.025 250);
-  font-family: var(--font-archivo);
+  font-family: var(--font-geist);
   font-size: 0.98rem;
   font-weight: 700;
   text-decoration: none;
@@ -209,7 +213,7 @@ h1, h2, h3 {
   align-self: flex-end;
   margin: 0;
   color: oklch(0.92 0.018 88);
-  font-family: var(--font-archivo);
+  font-family: var(--font-geist);
   font-size: 0.875rem;
 }
 

--- a/timing.mjs
+++ b/timing.mjs
@@ -19,6 +19,10 @@ export function withTiming(handler) {
       status: response.status,
       statusText: response.statusText,
       headers,
+      // A wrapped response with an existing encoding already contains encoded
+      // bytes. Preserve them verbatim instead of letting the Workers runtime
+      // encode the stream a second time.
+      ...(headers.has('content-encoding') ? { encodeBody: 'manual' } : {}),
     });
 
     // Log slow requests

--- a/worker.mjs
+++ b/worker.mjs
@@ -140,11 +140,11 @@ export default {
       // booting the full OpenNext stack (next-server, middleware handler,
       // Beasties pipeline, etc.). Cuts TTFB from ~250ms to ~30ms.
       //
-      // The Workers Static Assets binding does NOT auto-compress its
-      // responses (Lighthouse flagged ~80 KB wasted on uncompressed HTML
-      // even with CF Edge cache HIT). Compress with gzip here so the
-      // response — and the downstream CF Edge cache entry — is small.
-      // Only Astro overlay at `/` is static; marketing pages use edge HTML cache.
+      // Only the Astro overlay at `/` is static; marketing pages use the edge
+      // HTML cache. Leave content encoding to Cloudflare's response boundary.
+      // Manually piping this body through CompressionStream caused the timing
+      // wrapper and CDN to encode it again, leaving browsers with gzip bytes
+      // rendered as text after the cached variants crossed.
       if (env.ASSETS && url.pathname === '/') {
         const assetResp = await env.ASSETS.fetch(request);
         // The assets binding answers If-None-Match revalidations with 304.
@@ -156,29 +156,9 @@ export default {
           return new Response(null, { status: 304, headers });
         }
         if (assetResp.ok && assetResp.body) {
-          const acceptEnc = request.headers.get('accept-encoding') ?? '';
-          const wantsGzip = acceptEnc.includes('gzip');
           const headers = new Headers(assetResp.headers);
           headers.set('Cache-Control', CACHE_CONTROL);
           headers.set('x-edge-cache', 'ASSET');
-
-          if (wantsGzip && !headers.has('content-encoding')) {
-            headers.set('content-encoding', 'gzip');
-            headers.delete('content-length');
-            // `Vary: Accept-Encoding` so a future no-encoding client
-            // gets a separately negotiated entry.
-            const vary = headers.get('vary');
-            headers.set('vary', vary ? `${vary}, Accept-Encoding` : 'Accept-Encoding');
-            return new Response(assetResp.body.pipeThrough(new CompressionStream('gzip')), {
-              status: assetResp.status,
-              statusText: assetResp.statusText,
-              headers,
-              // Body is already gzip-encoded; without this the runtime
-              // gzips it a second time (encodeBody defaults to
-              // "automatic") and browsers receive garbled bytes.
-              encodeBody: 'manual',
-            });
-          }
 
           return new Response(assetResp.body, {
             status: assetResp.status,


### PR DESCRIPTION
## What changed

- restore the product typography pairing on the Astro landing: Fraunces for display text and Geist for body/interface text
- remove the Worker's unsafe manual gzip stream for the static homepage
- preserve already encoded response bodies when the timing middleware wraps them

## Why

The landing forced Archivo into both serif and sans roles, diverging from the app. More critically, the homepage could be manually gzipped and then encoded again by the timing/runtime boundary. A cached crossed variant exposed gzip bytes as visible text in browsers.

## Impact

The public landing renders readable HTML consistently across compression negotiation and now matches the established Life Atlas typography.

## Verification

- `pnpm --filter ./landing-astro build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 471 passed
- `pnpm cf:build`
- production-entrypoint identity → gzip → identity response checks
- browser screenshots at 390, 768, and 1440 pixels with zero horizontal overflow
- mobile and desktop Lighthouse: 100 accessibility, best practices, SEO, and agentic browsing

No schema changes or migrations.
