### PR TITLE
Complete Significant Hobbies search and agent surfaces

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -22,6 +22,11 @@ is the bridge between daily practice and life aspirations.
 
 ## Timeline
 
+- **2026-08-05:** Restored the full 42-article `/llms-full.txt` agent index by
+  keeping the portable Worker fallback from masking the application-owned
+  editorial route. The hobby quiz and Life in Weeks now publish self-canonical
+  URLs and complete social images, and public brand metadata consistently uses
+  Significant Hobbies. Production deployment remains manual.
 - **2026-08-03:** Corrected onboarding's planning assumptions locally. Future
   possibilities now search 5,202 distinct experience and hobby paths, accept a
   pasted numbered bucket list, and keep every selected or freely entered answer

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -73,7 +73,7 @@ test.describe('Landing page (Astro overlay)', () => {
   });
 
   test('carries a title and description for crawlers', async ({ page }) => {
-    expect(await page.title()).toContain('SignificantHobbies');
+    expect(await page.title()).toContain('Significant Hobbies');
     await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /.{40,}/);
   });
 

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -4,7 +4,7 @@ test.describe('SEO', () => {
   test('homepage has correct meta tags', async ({ page }) => {
     await page.goto('/');
     const title = await page.title();
-    expect(title).toContain('SignificantHobbies');
+    expect(title).toContain('Significant Hobbies');
   });
 
   test('pillar page exists', async ({ page }) => {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "SignificantHobbies",
+  "name": "Significant Hobbies",
   "short_name": "SigHobbies",
   "description": "Map your hobby journey across life phases",
   "start_url": "/",

--- a/src/app/find-your-hobby/page.tsx
+++ b/src/app/find-your-hobby/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { JsonLd } from '~/components/json-ld';
+import { DEFAULT_SOCIAL_IMAGE, SITE_URL } from '~/lib/site-metadata';
 
 import { HobbyQuiz } from './quiz-client';
 
@@ -8,9 +9,19 @@ export const metadata: Metadata = {
   title: 'Find Your Next Hobby — Hobby Quiz',
   description:
     'Take our free hobby quiz to discover your perfect hobby. Answer nine focused questions and get personalized recommendations based on your interests and preferred way of spending time.',
+  alternates: { canonical: '/find-your-hobby' },
   openGraph: {
     title: 'Find Your Next Hobby — Free Quiz',
     description: 'Answer nine focused questions. Get personalized hobby recommendations.',
+    url: '/find-your-hobby',
+    type: 'website',
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Find Your Next Hobby — Free Quiz',
+    description: 'Answer nine focused questions. Get personalized hobby recommendations.',
+    images: [DEFAULT_SOCIAL_IMAGE],
   },
 };
 
@@ -23,7 +34,7 @@ export default function FindYourHobbyPage() {
           '@type': 'WebApplication',
           name: 'Hobby Finder Quiz',
           description: 'Find your perfect hobby with our free personality quiz.',
-          url: 'https://significanthobbies.com/find-your-hobby',
+          url: `${SITE_URL}/find-your-hobby`,
           applicationCategory: 'LifestyleApplication',
           offers: { '@type': 'Offer', price: '0' },
         }}

--- a/src/app/life-in-weeks/page.tsx
+++ b/src/app/life-in-weeks/page.tsx
@@ -5,9 +5,10 @@ import { eq } from 'drizzle-orm';
 import { users } from '~/db/schema';
 import { getServerAuthSession } from '~/server/auth';
 import { db } from '~/server/db';
+import { BRAND_NAME, DEFAULT_SOCIAL_IMAGE } from '~/lib/site-metadata';
 
 export const metadata: Metadata = {
-  title: 'Your Life in Weeks — SignificantHobbies',
+  title: `Your Life in Weeks — ${BRAND_NAME}`,
   description:
     'See your whole life as one grid of weeks, using your exact birth date when available. Then decide what the remaining ones are for.',
   alternates: { canonical: '/life-in-weeks' },
@@ -17,6 +18,14 @@ export const metadata: Metadata = {
       'One square for every week of an average life. It takes one number to draw, and nobody needs to know you were here.',
     url: '/life-in-weeks',
     type: 'website',
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Your Life in Weeks',
+    description:
+      'One square for every week of an average life. It takes one number to draw, and nobody needs to know you were here.',
+    images: [DEFAULT_SOCIAL_IMAGE],
   },
 };
 

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,4 +1,5 @@
 import { type EditorialArticle, editorialArticles } from '~/lib/editorial-content';
+import { BRAND_NAME } from '~/lib/site-metadata';
 
 export function buildLlmArticleIndex(articles: EditorialArticle[]): string {
   const entries = articles
@@ -7,7 +8,7 @@ export function buildLlmArticleIndex(articles: EditorialArticle[]): string {
         `- [${article.title}](https://significanthobbies.com/blog/${article.slug}): ${article.excerpt}`
     )
     .join('\n');
-  return `# SignificantHobbies article index\n\nCanonical articles for agents and language models. Package-backed articles use the same URLs as human-facing blog pages.\n\n${entries}\n`;
+  return `# ${BRAND_NAME} article index\n\nCanonical articles for agents and language models. Package-backed articles use the same URLs as human-facing blog pages.\n\n${entries}\n`;
 }
 
 export function GET(request: Request) {

--- a/src/app/local-workspace/page.tsx
+++ b/src/app/local-workspace/page.tsx
@@ -1,9 +1,10 @@
 import { LocalRootExperience } from '~/components/local-root-experience';
+import { BRAND_NAME } from '~/lib/site-metadata';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata = {
-  title: 'Dashboard — SignificantHobbies',
+  title: `Dashboard — ${BRAND_NAME}`,
   robots: { index: false, follow: false },
 };
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -35,7 +35,7 @@ export default function OgImage() {
         >
           SH
         </div>
-        <span style={{ fontSize: 36, fontWeight: 700, color: '#1C1917' }}>SignificantHobbies</span>
+        <span style={{ fontSize: 36, fontWeight: 700, color: '#1C1917' }}>Significant Hobbies</span>
       </div>
 
       {/* Headline */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,13 +10,14 @@ import { bucketListItems, habitLogs, habits, journalEntries, users } from '~/db/
 import { dayKeyIn } from '~/lib/day';
 import { lifeInWeeksFromDate, parseBirthDate } from '~/lib/life-in-weeks';
 import { LOCAL_WORKSPACE_COOKIE } from '~/lib/local-workspace-cookie';
+import { BRAND_NAME } from '~/lib/site-metadata';
 import { getServerAuthSession } from '~/server/auth';
 import { db } from '~/server/db';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata = {
-  title: 'Dashboard — SignificantHobbies',
+  title: `Dashboard — ${BRAND_NAME}`,
   robots: { index: false, follow: false },
 };
 

--- a/src/lib/editorial-seo.test.ts
+++ b/src/lib/editorial-seo.test.ts
@@ -146,7 +146,7 @@ describe('editorial discovery and structured data', () => {
     );
     expect(markdown.headers.get('content-type')).toBe('text/markdown; charset=utf-8');
     expect(markdown.headers.get('vary')).toBe('Accept');
-    expect(await markdown.text()).toContain('# SignificantHobbies article index');
+    expect(await markdown.text()).toContain('# Significant Hobbies article index');
 
     const plain = getLlmIndex(new Request('https://significanthobbies.com/llms-full.txt'));
     expect(plain.headers.get('content-type')).toBe('text/plain; charset=utf-8');

--- a/worker.mjs
+++ b/worker.mjs
@@ -87,7 +87,10 @@ function hasLocalWorkspaceCookie(request) {
 export default {
   fetch: withTiming(async function fetch(request, env, ctx) {
     // Agent / LLM indexing surfaces (fleet GEO standard)
-    {
+    // `/llms-full.txt` is owned by the application because it is generated
+    // from the complete editorial corpus. The portable fallback must not mask
+    // that richer route with its generic product brief.
+    if (new URL(request.url).pathname !== '/llms-full.txt') {
       const agent = handleAgentEdge(request);
       if (agent) return agent;
     }


### PR DESCRIPTION
## What changed

- let the application-owned `/llms-full.txt` route serve its complete 42-article index instead of the portable Worker fallback
- give the hobby quiz and Life in Weeks self-canonical URLs and complete OG/Twitter images
- normalize the remaining critical public brand surfaces to `Significant Hobbies`
- fix the stale landing/SEO assertions that left main CI red

## Why

The structural agent audit passed, but the highest-value editorial entrypoint was being masked by a generic 1.2 KB brief. The metadata PR also left CI red and two public acquisition pages with incomplete canonical/social evidence.

## Checks

- `pnpm test` (48 files, 471 tests)
- focused editorial/agent tests (12/12)
- `pnpm typecheck`
- `pnpm build` (602 static pages)
- landing Astro build
- focused Biome check
- `pnpm docs:check`
- `git diff --check`

The local landing Playwright process could not start because this temporary worktree intentionally reused symlinked dependencies; GitHub CI installs isolated dependencies and is the authoritative landing E2E rerun.

Closes #60
