### PR TITLE
Prevent bucket-list ideas prerender crashes

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -27,6 +27,10 @@ is the bridge between daily practice and life aspirations.
   or signed-in habit; an explicitly entered practice still persists through
   the existing deduplicated paths. The browser contract also reflects the
   current balanced possibility shelf, including health.
+- **2026-08-09:** Restored `/bucket-list-ideas` prerendering after the shared
+  experience corpus added four category colors that the page did not style.
+  Every current group now has an explicit presentation and unknown future
+  colors fall back safely instead of crashing the production build.
 - **2026-08-06:** Reduced crawler-driven Worker CPU by edge-caching explicit
   public Markdown alternates, static experience and journey pages, and the two
   sitemap XML routes. Authenticated, personalized, query-bearing Markdown,

--- a/src/app/bucket-list-ideas/page.tsx
+++ b/src/app/bucket-list-ideas/page.tsx
@@ -10,6 +10,7 @@ import {
   StaggerItem,
 } from '~/components/aceternity';
 import { Whale } from '~/components/whale';
+import { getBucketListCategoryStyle } from '~/lib/bucket-list-category-styles';
 import { EXPERIENCES_BY_CATEGORY } from '~/lib/experiences';
 import { FAMOUS_BUCKET_LISTS } from '~/lib/famous-bucket-lists';
 
@@ -28,35 +29,6 @@ export const metadata: Metadata = {
 // The corpus moved to ~/lib/experiences so the suggestion engine and any
 // future surface can read it. This page renders it; it no longer owns it.
 const IDEAS_BY_CATEGORY = EXPERIENCES_BY_CATEGORY;
-
-const CATEGORY_STYLES = {
-  sky: { bg: 'bg-sky-50', border: 'border-sky-200', text: 'text-sky-700', dot: 'bg-sky-400' },
-  orange: {
-    bg: 'bg-orange-50',
-    border: 'border-orange-200',
-    text: 'text-orange-700',
-    dot: 'bg-orange-400',
-  },
-  purple: {
-    bg: 'bg-purple-50',
-    border: 'border-purple-200',
-    text: 'text-purple-700',
-    dot: 'bg-purple-400',
-  },
-  coral: {
-    bg: 'bg-primary/10',
-    border: 'border-lumi-200',
-    text: 'text-primary',
-    dot: 'bg-primary',
-  },
-  rose: { bg: 'bg-rose-50', border: 'border-rose-200', text: 'text-rose-700', dot: 'bg-rose-400' },
-  emerald: {
-    bg: 'bg-foreground/10',
-    border: 'border-foreground/20',
-    text: 'text-foreground',
-    dot: 'bg-foreground',
-  },
-};
 
 export default function BucketListIdeasPage() {
   const totalIdeas = Object.values(IDEAS_BY_CATEGORY).reduce(
@@ -116,7 +88,7 @@ export default function BucketListIdeasPage() {
         <div className="mx-auto max-w-5xl px-4 overflow-x-auto">
           <div className="flex gap-1 py-2 min-w-max">
             {Object.entries(IDEAS_BY_CATEGORY).map(([key, cat]) => {
-              const style = CATEGORY_STYLES[cat.color as keyof typeof CATEGORY_STYLES];
+              const style = getBucketListCategoryStyle(cat.color);
               return (
                 <a
                   key={key}
@@ -134,7 +106,7 @@ export default function BucketListIdeasPage() {
       {/* ── Ideas by category ────────────────────────────────────── */}
       <div className="mx-auto max-w-5xl px-4 py-12 space-y-16">
         {Object.entries(IDEAS_BY_CATEGORY).map(([key, cat]) => {
-          const style = CATEGORY_STYLES[cat.color as keyof typeof CATEGORY_STYLES];
+          const style = getBucketListCategoryStyle(cat.color);
           return (
             <section key={key} id={key} className="scroll-mt-28 space-y-6">
               <FadeIn>

--- a/src/lib/bucket-list-category-styles.test.ts
+++ b/src/lib/bucket-list-category-styles.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BUCKET_LIST_CATEGORY_STYLES,
+  getBucketListCategoryStyle,
+} from '~/lib/bucket-list-category-styles';
+import { EXPERIENCES_BY_CATEGORY } from '~/lib/experiences';
+
+describe('bucket-list category styles', () => {
+  it('defines an explicit style for every current experience group', () => {
+    for (const group of Object.values(EXPERIENCES_BY_CATEGORY)) {
+      expect(BUCKET_LIST_CATEGORY_STYLES).toHaveProperty(group.color);
+    }
+  });
+
+  it('falls back safely for an unexpected future color', () => {
+    expect(getBucketListCategoryStyle('future-color')).toEqual(BUCKET_LIST_CATEGORY_STYLES.emerald);
+  });
+});

--- a/src/lib/bucket-list-category-styles.ts
+++ b/src/lib/bucket-list-category-styles.ts
@@ -1,0 +1,75 @@
+export type BucketListCategoryStyle = {
+  bg: string;
+  border: string;
+  text: string;
+  dot: string;
+};
+
+export const BUCKET_LIST_CATEGORY_STYLES: Record<string, BucketListCategoryStyle> = {
+  amber: {
+    bg: 'bg-amber-50',
+    border: 'border-amber-200',
+    text: 'text-amber-700',
+    dot: 'bg-amber-400',
+  },
+  coral: {
+    bg: 'bg-primary/10',
+    border: 'border-lumi-200',
+    text: 'text-primary',
+    dot: 'bg-primary',
+  },
+  emerald: {
+    bg: 'bg-foreground/10',
+    border: 'border-foreground/20',
+    text: 'text-foreground',
+    dot: 'bg-foreground',
+  },
+  indigo: {
+    bg: 'bg-indigo-50',
+    border: 'border-indigo-200',
+    text: 'text-indigo-700',
+    dot: 'bg-indigo-400',
+  },
+  lime: {
+    bg: 'bg-lime-50',
+    border: 'border-lime-200',
+    text: 'text-lime-700',
+    dot: 'bg-lime-400',
+  },
+  orange: {
+    bg: 'bg-orange-50',
+    border: 'border-orange-200',
+    text: 'text-orange-700',
+    dot: 'bg-orange-400',
+  },
+  purple: {
+    bg: 'bg-purple-50',
+    border: 'border-purple-200',
+    text: 'text-purple-700',
+    dot: 'bg-purple-400',
+  },
+  rose: {
+    bg: 'bg-rose-50',
+    border: 'border-rose-200',
+    text: 'text-rose-700',
+    dot: 'bg-rose-400',
+  },
+  sky: {
+    bg: 'bg-sky-50',
+    border: 'border-sky-200',
+    text: 'text-sky-700',
+    dot: 'bg-sky-400',
+  },
+  teal: {
+    bg: 'bg-teal-50',
+    border: 'border-teal-200',
+    text: 'text-teal-700',
+    dot: 'bg-teal-400',
+  },
+};
+
+const FALLBACK_STYLE = BUCKET_LIST_CATEGORY_STYLES.emerald;
+
+export function getBucketListCategoryStyle(color: string): BucketListCategoryStyle {
+  return BUCKET_LIST_CATEGORY_STYLES[color] ?? FALLBACK_STYLE;
+}


### PR DESCRIPTION
## What changed

- moves bucket-list category presentation into a tested lookup
- adds explicit styles for the amber, lime, teal, and indigo groups already present in the canonical experience corpus
- adds a safe fallback for future unknown colors
- records the restored prerendering behavior in PROJECT_STATUS.md

## Root cause

The shared experience corpus had grown from six to ten category colors, but `/bucket-list-ideas` still cast every color to the older six-key style map. The missing entries returned undefined and prerendering crashed when the page read `.bg`.

## Validation

- focused regression tests: 2 passed
- full Vitest suite: 49 files, 474 tests passed
- typecheck passed
- lint passed with one pre-existing optional-chain warning
- docs validation passed
- Next.js production build prerendered all 699 pages successfully
- git diff --check passed

No deploy, migration, secret, dependency, or production configuration changed.

Closes #69