### PR TITLE
Honor optional onboarding habits

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -5,7 +5,7 @@
 > Update this file when durable current or shipped product truth changes. Do
 > not let deploy-version snapshots accumulate here — put those in the archive.
 
-Last updated: 2026-08-02
+Last updated: 2026-08-09
 
 ## Why / What
 
@@ -22,6 +22,11 @@ is the bridge between daily practice and life aspirations.
 
 ## Timeline
 
+- **2026-08-09:** Restored the onboarding promise that a daily practice is
+  optional. Choosing “Continue without a daily practice” now creates no local
+  or signed-in habit; an explicitly entered practice still persists through
+  the existing deduplicated paths. The browser contract also reflects the
+  current balanced possibility shelf, including health.
 - **2026-08-06:** Reduced crawler-driven Worker CPU by edge-caching explicit
   public Markdown alternates, static experience and journey pages, and the two
   sitemap XML routes. Authenticated, personalized, query-bearing Markdown,

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -151,6 +151,7 @@ test.describe('Onboarding', () => {
         'contribution',
         'creative',
         'food',
+        'health',
         'relationships',
         'travel',
       ].sort()
@@ -232,5 +233,7 @@ test.describe('Onboarding', () => {
     await page.getByRole('button', { name: /Enter my life/i }).click();
     await expect(page).toHaveURL(/\/$/);
     await expect(page.getByRole('heading', { name: /Live it, Complete/i })).toBeVisible();
+    await page.goto('/daily');
+    await expect(page.getByText('Connect with someone today', { exact: true })).toHaveCount(0);
   });
 });

--- a/src/app/onboarding/onboarding-flow.tsx
+++ b/src/app/onboarding/onboarding-flow.tsx
@@ -303,22 +303,6 @@ export function OnboardingFlow({
           commitmentId: null,
         });
       }
-      // Default relationship habit — see onboarding.ts for research rationale.
-      if (
-        !daily.habits.some(
-          (habit) => String(habit.name).toLowerCase() === 'connect with someone today'
-        )
-      ) {
-        daily.habits.push({
-          id: `local-habit-${crypto.randomUUID()}`,
-          name: 'Connect with someone today',
-          status: 'active',
-          targetFrequency: 'daily',
-          icon: '💬',
-          sourceQuestId: null,
-          commitmentId: null,
-        });
-      }
       await writeLocalRecord(adapter, 'daily:state', 'daily', daily);
       await createLocalTrajectory(trajectory, adapter).catch(() => undefined);
       syncLocalWorkspaceCookie(true);

--- a/src/lib/actions/onboarding.ts
+++ b/src/lib/actions/onboarding.ts
@@ -137,24 +137,6 @@ export async function completeOnboarding(
     }
   }
 
-  // Default relationship habit — the single most evidence-backed default.
-  // Harvard 85-year study, Blue Zones, World Happiness Report: relationships
-  // are the #1 predictor of happiness, health, and longevity. See
-  // docs/knowledge/learnings.md for the research synthesis.
-  const DEFAULT_RELATIONSHIP_HABIT = 'Connect with someone today';
-  if (
-    !allHabits.some(
-      (habit) => habit.name.trim().toLowerCase() === DEFAULT_RELATIONSHIP_HABIT.toLowerCase()
-    )
-  ) {
-    await db.insert(habits).values({
-      userId,
-      name: DEFAULT_RELATIONSHIP_HABIT,
-      status: 'active',
-      icon: '💬',
-    });
-  }
-
   const activeTrajectory = await db.query.trajectoryContracts.findFirst({
     where: and(eq(trajectoryContracts.userId, userId), eq(trajectoryContracts.status, 'active')),
     columns: { id: true },


### PR DESCRIPTION
## What changed

- removes the unconditional default relationship habit from both local and signed-in onboarding completion
- preserves creation and deduplication of a habit when the person explicitly enters one
- verifies the signed-in skip path exposes no injected habit on Daily
- updates the balanced popular-shelf assertion to include the already-shipped health category
- records the restored optionality contract in PROJECT_STATUS.md

## Root cause

The onboarding UI and product status both say the daily practice is optional, but completion appended “Connect with someone today” after the optional-habit branch regardless of the user’s choice. The popular shelf also gained a health item without updating its exact E2E category contract.

## Validation

- affected Playwright onboarding suite: 6 passed
- unit tests: 48 files, 472 tests passed
- typecheck passed
- lint passed with one pre-existing optional-chain warning
- docs validation passed
- git diff --check passed

The production build remains blocked on the independently tracked `/bucket-list-ideas` prerender bug in #69 / PR #70; this PR changes no bucket-list code.

No deploy, migration, secret, dependency, or production configuration changed.

Closes #71