### PR TITLE
Adopt Ultracite lint baseline

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -16,6 +16,9 @@ is the bridge between daily practice and life aspirations.
 
 ## Dependencies
 
+- Ultracite 7.10.2 supplies exact development-only shared Biome presets;
+  Significant Hobbies keeps explicit local compatibility exceptions and does
+  not ship Ultracite at runtime.
 - Cloudflare Workers/OpenNext, Cloudflare D1, Drizzle, better-auth Google OAuth,
   and PostHog. D1 is authoritative; the retired Turso database was deleted on
   2026-08-02.
@@ -31,6 +34,11 @@ is the bridge between daily practice and life aspirations.
   experience corpus added four category colors that the page did not style.
   Every current group now has an explicit presentation and unknown future
   colors fall back safely instead of crashing the production build.
+- **2026-08-09:** Adopted the verified Fleet Ultracite core, React, Next.js,
+  and Vitest Biome presets while retaining the repository's formatter contract,
+  generated-file exclusions, and explicit compatibility exceptions. No source
+  rewrite, production dependency, product behavior, route, migration, deploy,
+  secret, or production configuration changed.
 - **2026-08-06:** Reduced crawler-driven Worker CPU by edge-caching explicit
   public Markdown alternates, static experience and journey pages, and the two
   sitemap XML routes. Authenticated, personalized, query-bearing Markdown,

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "extends": [
+    "ultracite/biome/core",
+    "ultracite/biome/react",
+    "ultracite/biome/next",
+    "ultracite/biome/vitest"
+  ],
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,
@@ -41,25 +47,108 @@
       "jsxQuoteStyle": "double"
     }
   },
+  "json": { "formatter": { "enabled": false } },
   "linter": {
     "enabled": true,
     "rules": {
       "preset": "recommended",
-      "a11y": { "preset": "none" },
-      "style": { "noNonNullAssertion": "off" },
-      "performance": { "noImgElement": "off" },
+      "a11y": {
+        "preset": "none",
+        "noAriaHiddenOnFocusable": "off",
+        "noLabelWithoutControl": "off",
+        "noSvgWithoutTitle": "off",
+        "useAriaPropsSupportedByRole": "off",
+        "useButtonType": "off",
+        "useSemanticElements": "off"
+      },
+      "style": {
+        "noExportedImports": "off",
+        "noIncrementDecrement": "off",
+        "noInferrableTypes": "off",
+        "noNegationElse": "off",
+        "noNestedTernary": "off",
+        "noNonNullAssertion": "off",
+        "noParameterAssign": "off",
+        "noUnusedTemplateLiteral": "off",
+        "noUselessElse": "off",
+        "useAtIndex": "off",
+        "useBlockStatements": "off",
+        "useCollapsedIf": "off",
+        "useConsistentArrayType": "off",
+        "useConsistentArrowReturn": "off",
+        "useConsistentBuiltinInstantiation": "off",
+        "useConsistentMethodSignatures": "off",
+        "useConsistentObjectDefinitions": "off",
+        "useConsistentTypeDefinitions": "off",
+        "useDestructuring": "off",
+        "useErrorCause": "off",
+        "useFilenamingConvention": "off",
+        "useForOf": "off",
+        "useNumberNamespace": "off",
+        "useNumericSeparators": "off",
+        "useShorthandAssign": "off"
+      },
+      "performance": {
+        "noAwaitInLoops": "off",
+        "noBarrelFile": "off",
+        "noDelete": "off",
+        "noImgElement": "off",
+        "noJsxPropsBind": "off",
+        "noNamespaceImport": "off",
+        "useTopLevelRegex": "off"
+      },
       "suspicious": {
+        "noAlert": "off",
         "noExplicitAny": "off",
         "noArrayIndexKey": "off",
-        "noShadowRestrictedNames": "off"
+        "noBiomeFirstException": "off",
+        "noBitwiseOperators": "off",
+        "noEmptyBlockStatements": "off",
+        "noEqualsToNull": "off",
+        "noEvolvingTypes": "off",
+        "noLeakedRender": "off",
+        "noShadow": "off",
+        "noShadowRestrictedNames": "off",
+        "noSkippedTests": "off",
+        "noUnnecessaryConditions": "off",
+        "noUnusedExpressions": "off",
+        "useArraySortCompare": "off",
+        "useAwait": "off",
+        "useStaticResponseMethods": "off"
       },
       "security": { "noDangerouslySetInnerHtml": "off" },
       "correctness": {
+        "noGlobalDirnameFilename": "off",
+        "noUnusedInstantiation": "off",
         "useExhaustiveDependencies": "off",
+        "useImageSize": "off",
+        "useSingleJsDocAsterisk": "off",
         "noUnusedVariables": "off",
         "noUnusedImports": "off"
+      },
+      "complexity": {
+        "noExcessiveCognitiveComplexity": "off",
+        "noForEach": "off",
+        "noUselessUndefined": "off",
+        "noVoid": "off",
+        "useOptionalChain": "off",
+        "useSimplifiedLogicExpression": "off"
+      },
+      "nursery": {
+        "useSortedClasses": "off"
       }
     }
   },
-  "assist": { "enabled": true, "actions": { "source": { "organizeImports": "off" } } }
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "off",
+        "useSortedAttributes": "off",
+        "useSortedInterfaceMembers": "off",
+        "useSortedKeys": "off",
+        "useSortedPackageJson": "off"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "tsx": "4.23.1",
     "tw-animate-css": "1.4.0",
     "typescript": "6.0.3",
+    "ultracite": "7.10.2",
     "vitest": "4.1.10",
     "wrangler": "4.114.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      ultracite:
+        specifier: 7.10.2
+        version: 7.10.2
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.16.9)(tsx@4.23.1)(yaml@2.9.0))
@@ -5172,6 +5175,10 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -8360,6 +8367,18 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  ultracite@7.10.2:
+    resolution: {integrity: sha512-WP1Hu/BKy/BDgntaiU33uq2Y8hKL2gEO5li2wfg7XFvmlyIkGDEy8qbWg7GHsxTEjEpWOAKpyFSF8aqc3JNEGQ==}
+    hasBin: true
+    peerDependencies:
+      oxfmt: '>=0.1.0'
+      oxlint: ^1.0.0
+    peerDependenciesMeta:
+      oxfmt:
+        optional: true
+      oxlint:
+        optional: true
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
@@ -14081,8 +14100,7 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
-  citty@0.2.2:
-    optional: true
+  citty@0.2.2: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -14146,6 +14164,8 @@ snapshots:
   commander@11.1.0: {}
 
   commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@2.20.3: {}
 
@@ -16642,7 +16662,6 @@ snapshots:
       citty: 0.2.2
       pathe: 2.0.3
       tinyexec: 1.2.4
-    optional: true
 
   object-assign@4.1.1: {}
 
@@ -17961,6 +17980,18 @@ snapshots:
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
+
+  ultracite@7.10.2:
+    dependencies:
+      '@clack/prompts': 1.7.0
+      commander: 15.0.0
+      cross-spawn: 7.0.6
+      deepmerge: 4.3.1
+      glob: 13.0.6
+      jsonc-parser: 3.3.1
+      nypm: 0.6.8
+      yaml: 2.9.0
+      zod: 4.4.3
 
   ultrahtml@1.6.0: {}
 


### PR DESCRIPTION
## Summary

- add exact dev-only `ultracite@7.10.2`
- extend the core, React, Next.js, and Vitest Ultracite presets
- document compatibility exceptions for the existing codebase without rewriting product source
- record the shipped lint-baseline work in `PROJECT_STATUS.md`

The initial run reported 7,960 diagnostics. The configured baseline now checks 407 files with zero errors or warnings.

## Validation

- `pnpm exec ultracite check .` (407 files, 0 diagnostics)
- `pnpm exec ultracite format .` (387 files)
- `pnpm run typecheck`
- `pnpm test` (49 files, 474 tests)
- `pnpm run docs:validate`
- `pnpm run build` (699 pages)
- `git diff --check origin/main...HEAD`

Dependency-health evidence is unchanged pre-existing debt: pnpm audit reports 31 high and 0 critical advisories; strict Knip reports 14 unused files, 15 unused exports, 6 unused types, and configuration hints.

Closes #68
Supports sass-maker/fleet-workspace#249