### PR TITLE
perf: index hobby category lookups

### DIFF
--- a/src/lib/hobbies.ts
+++ b/src/lib/hobbies.ts
@@ -191,6 +191,12 @@ export const HOBBY_CATEGORIES: HobbyCategory[] = [
 
 export const ALL_HOBBIES = HOBBY_CATEGORIES.flatMap((c) => c.hobbies);
 
+const CATEGORY_BY_HOBBY = new Map(
+  HOBBY_CATEGORIES.flatMap((category) =>
+    category.hobbies.map((hobby) => [hobby.toLowerCase(), category] as const)
+  )
+);
+
 /**
  * Hobbies that ask a lot of the body. Used to keep a set of suggestions from
  * being uniformly strenuous — not to hide anything from anyone.
@@ -248,8 +254,7 @@ export function pickAcrossEffort(hobbies: string[], limit = 3): string[] {
 }
 
 export function getCategoryForHobby(hobby: string): HobbyCategory | undefined {
-  const lower = hobby.toLowerCase();
-  return HOBBY_CATEGORIES.find((c) => c.hobbies.some((h) => h.toLowerCase() === lower));
+  return CATEGORY_BY_HOBBY.get(hobby.toLowerCase());
 }
 
 export function getSuggestedHobbies(existingHobbies: string[], limit = 6): string[] {


### PR DESCRIPTION
## What
- pre-index the static hobby catalog by normalized hobby name
- replace repeated category find plus nested hobby some scans with map lookup

## Why
CodeVetter found and paired-confirmed the nested lookup hotspot:
- 35,000 phases: 9.116 to 1.810 ms/op (-80.145%)
- 10,000 phases: -71.658%
- 1,000 phases: -62.103%
- endpoint exponent: 0.814 to 0.633

An earlier two-pass merge improved only 2.962%, was classified inconclusive, and was reverted.

## Checks
- 44 permanent hobby/recommendation tests passed
- TypeScript typecheck
- complete Biome lint
- rebased onto current main