### PR TITLE
Expose public Significant Hobbies reads for ChatGPT

### DIFF
--- a/src/app/api/mcp/experiences/[slug]/route.ts
+++ b/src/app/api/mcp/experiences/[slug]/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+import { getPublicExperience } from '@/lib/mcp-public';
+
+export function GET(_request: Request, context: { params: Promise<{ slug: string }> }) {
+  return context.params.then(({ slug }) => {
+    const item = getPublicExperience(slug);
+    return item
+      ? NextResponse.json({ item }, { headers: { 'Cache-Control': 'public, max-age=86400' } })
+      : NextResponse.json({ code: 'NOT_FOUND', message: 'Experience not found.' }, { status: 404 });
+  });
+}

--- a/src/app/api/mcp/experiences/route.ts
+++ b/src/app/api/mcp/experiences/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+import { searchPublicExperiences } from '@/lib/mcp-public';
+
+export function GET(request: Request) {
+  return NextResponse.json(searchPublicExperiences(new URL(request.url).searchParams), {
+    headers: { 'Cache-Control': 'public, max-age=3600, s-maxage=86400' },
+  });
+}

--- a/src/app/api/mcp/hobbies/route.ts
+++ b/src/app/api/mcp/hobbies/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+import { searchPublicHobbies } from '@/lib/mcp-public';
+
+export function GET(request: Request) {
+  return NextResponse.json(searchPublicHobbies(new URL(request.url).searchParams), {
+    headers: { 'Cache-Control': 'public, max-age=3600, s-maxage=86400' },
+  });
+}

--- a/src/app/api/mcp/timelines/[id]/route.ts
+++ b/src/app/api/mcp/timelines/[id]/route.ts
@@ -1,0 +1,33 @@
+import { and, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { timelines, users } from '~/db/schema';
+import { db } from '~/server/db';
+import { publicTimelineRecord } from '@/lib/mcp-public';
+
+export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const [row] = await db
+    .select({
+      id: timelines.id,
+      title: timelines.title,
+      visibility: timelines.visibility,
+      slug: timelines.slug,
+      phases: timelines.phases,
+      createdAt: timelines.createdAt,
+      updatedAt: timelines.updatedAt,
+      userName: users.name,
+      userUsername: users.username,
+    })
+    .from(timelines)
+    .leftJoin(users, eq(timelines.userId, users.id))
+    .where(and(eq(timelines.id, id), eq(timelines.visibility, 'PUBLIC')))
+    .limit(1);
+  const item = row ? publicTimelineRecord(row) : null;
+  return item
+    ? NextResponse.json({ item }, { headers: { 'Cache-Control': 'public, max-age=300' } })
+    : NextResponse.json(
+        { code: 'NOT_FOUND', message: 'Public timeline not found.' },
+        { status: 404 }
+      );
+}

--- a/src/app/api/mcp/timelines/route.ts
+++ b/src/app/api/mcp/timelines/route.ts
@@ -1,0 +1,44 @@
+import { and, desc, eq, like } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { timelines, users } from '~/db/schema';
+import { db } from '~/server/db';
+import { boundedPage, publicTimelineRecord } from '@/lib/mcp-public';
+
+export async function GET(request: Request) {
+  const searchParams = new URL(request.url).searchParams;
+  const { limit, offset } = boundedPage(searchParams);
+  const q = searchParams.get('q')?.trim().replaceAll(/[%_]/g, '').slice(0, 120) ?? '';
+  const where = q
+    ? and(eq(timelines.visibility, 'PUBLIC'), like(timelines.title, `%${q}%`))
+    : eq(timelines.visibility, 'PUBLIC');
+  const rows = await db
+    .select({
+      id: timelines.id,
+      title: timelines.title,
+      visibility: timelines.visibility,
+      slug: timelines.slug,
+      phases: timelines.phases,
+      createdAt: timelines.createdAt,
+      updatedAt: timelines.updatedAt,
+      userName: users.name,
+      userUsername: users.username,
+    })
+    .from(timelines)
+    .leftJoin(users, eq(timelines.userId, users.id))
+    .where(where)
+    .orderBy(desc(timelines.updatedAt))
+    .limit(limit + 1)
+    .offset(offset);
+  const hasMore = rows.length > limit;
+  const items = rows
+    .slice(0, limit)
+    .map(publicTimelineRecord)
+    .filter((item) => item !== null);
+  return NextResponse.json({
+    generatedAt: new Date().toISOString(),
+    items,
+    total: offset + items.length + (hasMore ? 1 : 0),
+    nextOffset: hasMore ? offset + items.length : null,
+  });
+}

--- a/src/lib/mcp-public.test.ts
+++ b/src/lib/mcp-public.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getPublicExperience,
+  publicTimelineRecord,
+  searchPublicExperiences,
+  searchPublicHobbies,
+} from './mcp-public';
+
+describe('public MCP projections', () => {
+  it('bounds and filters hobby results', () => {
+    const result = searchPublicHobbies(new URLSearchParams({ facet: 'gentle', limit: '3' }));
+    expect(result.items).toHaveLength(3);
+    expect(result.items.every((item) => item.facets.includes('gentle'))).toBe(true);
+    expect(result.nextOffset).toBe(3);
+  });
+
+  it('returns stable experience detail with bounded related records', () => {
+    const search = searchPublicExperiences(new URLSearchParams({ q: 'marathon', limit: '5' }));
+    expect(search.items.length).toBeGreaterThan(0);
+    const item = getPublicExperience(search.items[0]!.slug);
+    expect(item?.canonicalUrl).toContain('/experiences/');
+    expect(item?.related.length).toBeLessThanOrEqual(6);
+  });
+
+  it('fails closed for non-public timeline records', () => {
+    const base = {
+      id: 'timeline-1',
+      title: 'Visible title',
+      slug: 'visible-title',
+      phases: '[]',
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-02T00:00:00Z'),
+      userName: 'Owner',
+      userUsername: 'owner',
+    };
+    expect(publicTimelineRecord({ ...base, visibility: 'PRIVATE' })).toBeNull();
+    expect(publicTimelineRecord({ ...base, visibility: 'UNLISTED' })).toBeNull();
+    expect(publicTimelineRecord({ ...base, visibility: 'PUBLIC' })?.id).toBe('timeline-1');
+  });
+});

--- a/src/lib/mcp-public.ts
+++ b/src/lib/mcp-public.ts
@@ -1,0 +1,120 @@
+import { HOBBY_CATEGORIES, HOBBY_FACETS } from '@/lib/hobbies';
+import {
+  EXPERIENCE_ENTRIES,
+  findExperience,
+  firstSteps,
+  relatedExperiences,
+} from '@/lib/experiences';
+
+export const MCP_PAGE_MAX = 50;
+
+export function boundedPage(searchParams: URLSearchParams) {
+  const parsedLimit = Number(searchParams.get('limit') ?? 10);
+  const parsedOffset = Number(searchParams.get('offset') ?? 0);
+  return {
+    limit: Number.isInteger(parsedLimit) ? Math.min(Math.max(parsedLimit, 1), MCP_PAGE_MAX) : 10,
+    offset: Number.isInteger(parsedOffset) ? Math.min(Math.max(parsedOffset, 0), 10_000) : 0,
+  };
+}
+
+function page<T>(items: T[], limit: number, offset: number) {
+  const selected = items.slice(offset, offset + limit);
+  return {
+    generatedAt: new Date().toISOString(),
+    items: selected,
+    total: items.length,
+    nextOffset: offset + selected.length < items.length ? offset + selected.length : null,
+  };
+}
+
+export function searchPublicHobbies(searchParams: URLSearchParams) {
+  const q = searchParams.get('q')?.trim().toLocaleLowerCase() ?? '';
+  const category = searchParams.get('category')?.trim().toLocaleLowerCase() ?? '';
+  const facet = searchParams.get('facet')?.trim().toLocaleLowerCase() ?? '';
+  const { limit, offset } = boundedPage(searchParams);
+  const hobbies = HOBBY_CATEGORIES.flatMap((group) =>
+    group.hobbies.map((name) => ({
+      id: name
+        .toLocaleLowerCase()
+        .replaceAll(/[^a-z0-9]+/g, '-')
+        .replaceAll(/^-|-$/g, ''),
+      name,
+      category: group.name,
+      emoji: group.emoji,
+      facets: HOBBY_FACETS[name] ?? [],
+      canonicalUrl: `https://significanthobbies.com/hobbies/${encodeURIComponent(name.toLocaleLowerCase().replaceAll(' ', '-'))}`,
+    }))
+  ).filter(
+    (item) =>
+      (!q ||
+        `${item.name} ${item.category} ${item.facets.join(' ')}`.toLocaleLowerCase().includes(q)) &&
+      (!category || item.category.toLocaleLowerCase() === category) &&
+      (!facet || item.facets.includes(facet as (typeof item.facets)[number]))
+  );
+  return page(hobbies, limit, offset);
+}
+
+export function searchPublicExperiences(searchParams: URLSearchParams) {
+  const q = searchParams.get('q')?.trim().toLocaleLowerCase() ?? '';
+  const category = searchParams.get('category')?.trim().toLocaleLowerCase() ?? '';
+  const { limit, offset } = boundedPage(searchParams);
+  const experiences = EXPERIENCE_ENTRIES.filter(
+    (item) =>
+      (!q || `${item.title} ${item.description ?? ''}`.toLocaleLowerCase().includes(q)) &&
+      (!category || item.category.toLocaleLowerCase() === category)
+  ).map((item) => ({
+    ...item,
+    canonicalUrl: `https://significanthobbies.com/experiences/${item.slug}`,
+  }));
+  return page(experiences, limit, offset);
+}
+
+export function getPublicExperience(slug: string) {
+  const experience = findExperience(slug);
+  if (!experience) return null;
+  return {
+    ...experience,
+    firstSteps: firstSteps(experience),
+    related: relatedExperiences(experience).map((item) => ({
+      slug: item.slug,
+      title: item.title,
+      category: item.category,
+      canonicalUrl: `https://significanthobbies.com/experiences/${item.slug}`,
+    })),
+    canonicalUrl: `https://significanthobbies.com/experiences/${experience.slug}`,
+  };
+}
+
+export function publicTimelineRecord(row: {
+  id: string;
+  title: string | null;
+  visibility: string;
+  slug: string | null;
+  phases: string;
+  createdAt: Date;
+  updatedAt: Date;
+  userName: string | null;
+  userUsername: string | null;
+}) {
+  if (row.visibility !== 'PUBLIC') return null;
+  let phases: unknown[] = [];
+  try {
+    const parsed = JSON.parse(row.phases) as unknown;
+    if (Array.isArray(parsed)) phases = parsed;
+  } catch {
+    phases = [];
+  }
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    phases,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    user: row.userName ? { name: row.userName, username: row.userUsername } : null,
+    canonicalUrl:
+      row.userUsername && row.slug
+        ? `https://significanthobbies.com/u/${encodeURIComponent(row.userUsername)}/${encodeURIComponent(row.slug)}`
+        : `https://significanthobbies.com/timeline/${encodeURIComponent(row.id)}`,
+  };
+}


### PR DESCRIPTION
Adds bounded public hobby, experience, and explicitly PUBLIC timeline routes. Private and unlisted timelines plus Daily, journal, habits, Trajectory, commitments, bucket lists, accounts, and device-local data remain unreachable.

Validation: 477 tests, TypeScript, and Biome check pass.

Fleet change: https://github.com/sass-maker/fleet-workspace/issues/286