### PR TITLE
fix(mcp): tolerate legacy timeline timestamps

### DIFF
--- a/src/lib/mcp-public.test.ts
+++ b/src/lib/mcp-public.test.ts
@@ -38,4 +38,34 @@ describe('public MCP projections', () => {
     expect(publicTimelineRecord({ ...base, visibility: 'UNLISTED' })).toBeNull();
     expect(publicTimelineRecord({ ...base, visibility: 'PUBLIC' })?.id).toBe('timeline-1');
   });
+
+  it('normalizes legacy timestamps without failing the public timeline projection', () => {
+    const base = {
+      id: 'timeline-1',
+      title: 'Visible title',
+      visibility: 'PUBLIC',
+      slug: 'visible-title',
+      phases: '[]',
+      userName: 'Owner',
+      userUsername: 'owner',
+    };
+
+    expect(
+      publicTimelineRecord({
+        ...base,
+        createdAt: 1_767_225_600,
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      })
+    ).toMatchObject({
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    });
+    expect(
+      publicTimelineRecord({
+        ...base,
+        createdAt: null,
+        updatedAt: new Date('invalid'),
+      })
+    ).toMatchObject({ createdAt: null, updatedAt: null });
+  });
 });

--- a/src/lib/mcp-public.ts
+++ b/src/lib/mcp-public.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/experiences';
 
 export const MCP_PAGE_MAX = 50;
+const EPOCH_MILLISECONDS_THRESHOLD = 10_000_000_000;
 
 export function boundedPage(searchParams: URLSearchParams) {
   const parsedLimit = Number(searchParams.get('limit') ?? 10);
@@ -91,8 +92,8 @@ export function publicTimelineRecord(row: {
   visibility: string;
   slug: string | null;
   phases: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: Date | number | string | null;
+  updatedAt: Date | number | string | null;
   userName: string | null;
   userUsername: string | null;
 }) {
@@ -109,12 +110,32 @@ export function publicTimelineRecord(row: {
     title: row.title,
     slug: row.slug,
     phases,
-    createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString(),
+    createdAt: publicTimestamp(row.createdAt),
+    updatedAt: publicTimestamp(row.updatedAt),
     user: row.userName ? { name: row.userName, username: row.userUsername } : null,
     canonicalUrl:
       row.userUsername && row.slug
         ? `https://significanthobbies.com/u/${encodeURIComponent(row.userUsername)}/${encodeURIComponent(row.slug)}`
         : `https://significanthobbies.com/timeline/${encodeURIComponent(row.id)}`,
   };
+}
+
+function publicTimestamp(value: Date | number | string | null): string | null {
+  let parsed: Date;
+  if (value instanceof Date) {
+    parsed = value;
+  } else if (typeof value === 'number') {
+    parsed = numericTimestamp(value);
+  } else if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value);
+    parsed = Number.isFinite(numeric) ? numericTimestamp(numeric) : new Date(value);
+  } else {
+    return null;
+  }
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function numericTimestamp(value: number): Date {
+  const milliseconds = Math.abs(value) < EPOCH_MILLISECONDS_THRESHOLD ? value * 1000 : value;
+  return new Date(milliseconds);
 }


### PR DESCRIPTION
## Summary

- normalize Date, epoch-second, epoch-millisecond, and ISO timestamp forms in the public MCP timeline projection
- return `null` for an invalid legacy timestamp instead of failing the entire PUBLIC list or detail response
- add regression coverage for valid legacy and corrupt timestamp forms

## Why

The production public MCP timeline list and detail routes both return HTTP 500 for a current PUBLIC record, while the older demo query succeeds. Both failing routes share the projection's unconditional timestamp serialization. Legacy D1 timestamp shapes must not make the whole public read surface unavailable.

PUBLIC-only filtering, bounded pagination, canonical URLs, and private/unlisted exclusion remain unchanged.

## Validation

- focused MCP projection tests — 4 passed
- full Vitest suite — 50 files / 478 tests passed
- `pnpm typecheck`
- `pnpm check` — Biome passed
- `pnpm build` — 702 pages generated; MCP routes compiled
- `git diff --check`

No migration or deployment was run. Production status re-probes remain deployment-gated.

Closes #80
