### PR TITLE
Add native Sign in with Apple

### DIFF
--- a/ios/RELEASE_METADATA.md
+++ b/ios/RELEASE_METADATA.md
@@ -60,12 +60,7 @@ Confirm the rating produced by App Store Connect's current questionnaire.
 
 ## Review notes draft
 
-The app works in local mode. Daily writing intentionally has no sharing control. To inspect the opt-in boundary, open a hobby and choose its Private status; the confirmation explains that only the selected eligible item changes. Account sync uses Google sign-in and stores a private revisioned Life Atlas; a conflict always requires an explicit copy choice.
-
-Do not submit this build for App Review until Sign in with Apple is implemented
-and configured as an equivalent login option, or the Google login is removed;
-neither exception in App Review Guideline 4.8 applies to this primary account
-flow. Internal TestFlight testing may proceed while this is completed.
+The app works in local mode. Daily writing intentionally has no sharing control. To inspect the opt-in boundary, open a hobby and choose its Private status; the confirmation explains that only the selected eligible item changes. Account sync offers Sign in with Apple beside Google and stores a private revisioned Life Atlas; a conflict always requires an explicit copy choice. Existing Google users add Apple explicitly while authenticated, and matching email text never silently merges identities. Apple tokens are nonce-bound and validated for `com.significanthobbies.app`.
 
 ## Screenshots and release
 

--- a/ios/SignificantHobbies.xcodeproj/project.pbxproj
+++ b/ios/SignificantHobbies.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		124A5B25ECB89C00310C66CD /* DailyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyView.swift; sourceTree = "<group>"; };
 		24C7DF31D7BBD34A504FB0B5 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		3D99A5939D824B344E6704A9 /* Design.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Design.swift; sourceTree = "<group>"; };
+		45756EFDB3A45F83CBF63F78 /* SignificantHobbies.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SignificantHobbies.entitlements; sourceTree = "<group>"; };
 		48EFA0E8BD9B98537969A433 /* SignificantHobbies.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SignificantHobbies.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B5197DAFED5BEB3D8E1FF6B /* SignificantHobbiesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignificantHobbiesUITests.swift; sourceTree = "<group>"; };
 		55CADA0312E38B323127C310 /* SignificantHobbiesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignificantHobbiesApp.swift; sourceTree = "<group>"; };
@@ -159,6 +160,7 @@
 				0C2B9B72A49B3D8612FD520D /* NativeAccountClient.swift */,
 				AD5D1654F75D6BD52DEA4738 /* RootView.swift */,
 				AE73F47A9024224B92970695 /* SettingsView.swift */,
+				45756EFDB3A45F83CBF63F78 /* SignificantHobbies.entitlements */,
 				55CADA0312E38B323127C310 /* SignificantHobbiesApp.swift */,
 				7EC577B16F8FF0D0139D8374 /* Resources */,
 			);
@@ -595,6 +597,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Sources/SignificantHobbies/SignificantHobbies.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = Sources/SignificantHobbies/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -636,6 +639,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Sources/SignificantHobbies/SignificantHobbies.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = Sources/SignificantHobbies/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/Sources/SignificantHobbies/AppModel.swift
+++ b/ios/Sources/SignificantHobbies/AppModel.swift
@@ -46,12 +46,20 @@ final class AppModel {
             document = ProcessInfo.processInfo.arguments.contains("--fresh-demo") ? .sample : try await store.load()
             if ProcessInfo.processInfo.arguments.contains("--daily-demo") { selectedDate = .now }
             if ProcessInfo.processInfo.arguments.contains("--account-demo") {
-                account = SignificantHobbiesAccount(name: "Sarthak", email: "sarthak@example.com")
+                account = SignificantHobbiesAccount(
+                    name: "Sarthak",
+                    email: "sarthak@example.com",
+                    providers: ["google"]
+                )
                 document.syncState = .synced
                 document.lastSyncedAt = Date().addingTimeInterval(-240)
                 isSettingsPresented = true
             } else if ProcessInfo.processInfo.arguments.contains("--account-conflict-demo") {
-                account = SignificantHobbiesAccount(name: "Sarthak", email: "sarthak@example.com")
+                account = SignificantHobbiesAccount(
+                    name: "Sarthak",
+                    email: "sarthak@example.com",
+                    providers: ["google"]
+                )
                 document.syncState = .conflict
                 var accountDocument = document
                 accountDocument.hobbies.append(Hobby(name: "Ceramics", category: "Make"))
@@ -172,6 +180,23 @@ final class AppModel {
         } catch let error as NSError
             where error.domain == ASWebAuthenticationSessionErrorDomain && error.code == 1 {
             accountMessage = nil
+        } catch {
+            accountMessage = friendlyMessage(for: error)
+        }
+    }
+
+    func completeAppleSignIn(_ payload: AppleIdentityPayload) async {
+        isAccountBusy = true
+        accountMessage = nil
+        defer { isAccountBusy = false }
+        do {
+            if let account, !account.hasApple {
+                self.account = try await accountClient.linkApple(payload)
+                accountMessage = "Apple sign-in added to this Significant Hobbies account."
+            } else {
+                account = try await accountClient.signInWithApple(payload)
+            }
+            try await reconcileAccountCopy()
         } catch {
             accountMessage = friendlyMessage(for: error)
         }

--- a/ios/Sources/SignificantHobbies/NativeAccountClient.swift
+++ b/ios/Sources/SignificantHobbies/NativeAccountClient.swift
@@ -1,12 +1,24 @@
 import AuthenticationServices
+import CryptoKit
 import Foundation
 import Security
 import SignificantHobbiesCore
 import UIKit
 
+struct AppleIdentityPayload: Sendable {
+    let identityToken: String
+    let nonce: String
+    let email: String?
+    let firstName: String?
+    let lastName: String?
+}
+
 struct SignificantHobbiesAccount: Equatable, Sendable {
     let name: String
     let email: String
+    let providers: Set<String>
+
+    var hasApple: Bool { providers.contains("apple") }
 }
 
 enum NativeAccountError: LocalizedError {
@@ -144,6 +156,20 @@ actor SignificantHobbiesNativeAccountClient {
         return try await account()
     }
 
+    func signInWithApple(_ payload: AppleIdentityPayload) async throws -> SignificantHobbiesAccount {
+        let response = try await appleRequest(path: "/api/auth/sign-in/social", payload: payload)
+        guard let token = response.response.value(forHTTPHeaderField: "set-auth-token") else {
+            throw NativeAccountError.missingSession
+        }
+        try await sessionStore.save(token)
+        return try await account()
+    }
+
+    func linkApple(_ payload: AppleIdentityPayload) async throws -> SignificantHobbiesAccount {
+        _ = try await appleRequest(path: "/api/auth/link-social", payload: payload, authenticated: true)
+        return try await account()
+    }
+
     func fetchState() async throws -> AtlasCloudSnapshot? {
         let data = try await request(path: "/api/native/state", method: "GET")
         return try decoder.decode(StateResponse.self, from: data).state
@@ -172,10 +198,39 @@ actor SignificantHobbiesNativeAccountClient {
         try await sessionStore.delete()
     }
 
+    private func appleRequest(
+        path: String,
+        payload: AppleIdentityPayload,
+        authenticated: Bool = false
+    ) async throws -> NetworkResponse {
+        var idToken: [String: Any] = ["token": payload.identityToken, "nonce": payload.nonce]
+        if path.hasSuffix("sign-in/social") {
+            var user: [String: Any] = [:]
+            if let email = payload.email { user["email"] = email }
+            var name: [String: String] = [:]
+            if let firstName = payload.firstName { name["firstName"] = firstName }
+            if let lastName = payload.lastName { name["lastName"] = lastName }
+            if !name.isEmpty { user["name"] = name }
+            if !user.isEmpty { idToken["user"] = user }
+        }
+        return try await networkRequest(
+            path: path,
+            method: "POST",
+            data: try JSONSerialization.data(withJSONObject: ["provider": "apple", "idToken": idToken]),
+            authenticated: authenticated
+        )
+    }
+
     private func account() async throws -> SignificantHobbiesAccount {
         let data = try await request(path: "/api/auth/get-session", method: "GET")
         let session = try decoder.decode(SessionResponse.self, from: data)
-        return SignificantHobbiesAccount(name: session.user.name, email: session.user.email)
+        let accountsData = try await request(path: "/api/auth/list-accounts", method: "GET")
+        let accounts = try decoder.decode([ProviderAccount].self, from: accountsData)
+        return SignificantHobbiesAccount(
+            name: session.user.name,
+            email: session.user.email,
+            providers: Set(accounts.map(\.providerId))
+        )
     }
 
     private func request(
@@ -202,6 +257,20 @@ actor SignificantHobbiesNativeAccountClient {
         data: Data? = nil,
         authenticated: Bool = true
     ) async throws -> Data {
+        try await networkRequest(
+            path: path,
+            method: method,
+            data: data,
+            authenticated: authenticated
+        ).data
+    }
+
+    private func networkRequest(
+        path: String,
+        method: String,
+        data: Data? = nil,
+        authenticated: Bool = true
+    ) async throws -> NetworkResponse {
         var request = URLRequest(url: endpoint(path))
         request.httpMethod = method
         request.httpBody = data
@@ -225,7 +294,7 @@ actor SignificantHobbiesNativeAccountClient {
             if response.statusCode == 401 { throw NativeAccountError.missingSession }
             throw NativeAccountError.http(response.statusCode, message)
         }
-        return responseData
+        return NetworkResponse(data: responseData, response: response)
     }
 
     private func endpoint(_ path: String) -> URL {
@@ -242,6 +311,17 @@ actor SignificantHobbiesNativeAccountClient {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return decoder
+    }
+}
+
+enum AppleNonce {
+    static func make() -> String {
+        let alphabet = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        return String((0..<32).map { _ in alphabet.randomElement()! })
+    }
+
+    static func digest(_ nonce: String) -> String {
+        SHA256.hash(data: Data(nonce.utf8)).map { String(format: "%02x", $0) }.joined()
     }
 }
 
@@ -292,6 +372,8 @@ final class SignificantHobbiesWebAuthenticator: NSObject, ASWebAuthenticationPre
 private struct TokenResponse: Decodable { let token: String }
 private struct SessionResponse: Decodable { let user: SessionUser }
 private struct SessionUser: Decodable { let name: String; let email: String }
+private struct ProviderAccount: Decodable { let providerId: String }
+private struct NetworkResponse { let data: Data; let response: HTTPURLResponse }
 private struct ErrorResponse: Decodable { let message: String }
 private struct StateResponse: Decodable { let state: AtlasCloudSnapshot? }
 private struct StateWrite: Encodable {

--- a/ios/Sources/SignificantHobbies/SettingsView.swift
+++ b/ios/Sources/SignificantHobbies/SettingsView.swift
@@ -1,14 +1,17 @@
+import AuthenticationServices
 import SignificantHobbiesCore
 import SwiftUI
 import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @Environment(AppModel.self) private var model
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dismiss) private var dismiss
     @State private var isProfileEditorPresented = false
     @State private var isImporterPresented = false
     @State private var showReset = false
     @State private var showDeleteAccount = false
+    @State private var appleNonce = AppleNonce.make()
 
     var body: some View {
         @Bindable var model = model
@@ -46,6 +49,7 @@ struct SettingsView: View {
                                 Label("Connect Google account", systemImage: "person.crop.circle.badge.plus")
                             }
                             .buttonStyle(AtlasPrimaryButtonStyle())
+                            appleAccountButton
                         } else {
                             if let lastSync = model.document.lastSyncedAt {
                                 LabeledContent("Last synced") {
@@ -56,6 +60,12 @@ struct SettingsView: View {
                                 Label("Sync private Life Atlas", systemImage: "arrow.triangle.2.circlepath")
                             }
                             .buttonStyle(AtlasPrimaryButtonStyle())
+                            if model.account?.hasApple == false {
+                                Text("Add Apple to this account so future Apple sign-ins open the same private Life Atlas.")
+                                    .font(.footnote)
+                                    .foregroundStyle(AtlasPalette.quietInk)
+                                appleAccountButton
+                            }
                             Button { Task { await model.signOut() } } label: {
                                 Label("Sign out", systemImage: "rectangle.portrait.and.arrow.right")
                                     .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
@@ -182,6 +192,40 @@ struct SettingsView: View {
             }
             .interactiveDismissDisabled()
         }
+    }
+
+    private var appleAccountButton: some View {
+        SignInWithAppleButton(.continue) { request in
+            appleNonce = AppleNonce.make()
+            request.requestedScopes = [.fullName, .email]
+            request.nonce = AppleNonce.digest(appleNonce)
+        } onCompletion: { result in
+            guard
+                case let .success(authorization) = result,
+                let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                let tokenData = credential.identityToken,
+                let token = String(data: tokenData, encoding: .utf8)
+            else {
+                if case let .failure(error) = result,
+                   (error as? ASAuthorizationError)?.code != .canceled {
+                    model.accountMessage = error.localizedDescription
+                }
+                return
+            }
+            let payload = AppleIdentityPayload(
+                identityToken: token,
+                nonce: appleNonce,
+                email: credential.email,
+                firstName: credential.fullName?.givenName,
+                lastName: credential.fullName?.familyName
+            )
+            Task { await model.completeAppleSignIn(payload) }
+        }
+        .signInWithAppleButtonStyle(colorScheme == .dark ? .white : .black)
+        .frame(maxWidth: .infinity, minHeight: 48)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .accessibilityIdentifier("apple-account-button")
+        .disabled(model.isAccountBusy)
     }
 
     private var publicPreview: some View {

--- a/ios/Sources/SignificantHobbies/SignificantHobbies.entitlements
+++ b/ios/Sources/SignificantHobbies/SignificantHobbies.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/ios/Tests/SignificantHobbiesUITests/SignificantHobbiesUITests.swift
+++ b/ios/Tests/SignificantHobbiesUITests/SignificantHobbiesUITests.swift
@@ -43,4 +43,14 @@ final class SignificantHobbiesUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Export Life Atlas"].exists)
         XCTAssertTrue(app.buttons["Delete account and cloud copy"].exists)
     }
+
+    func testAccountScreenOffersAppleAlongsideGoogle() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--fresh-demo"]
+        app.launch()
+
+        app.buttons["Profile and settings"].tap()
+        XCTAssertTrue(app.buttons["Connect Google account"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["apple-account-button"].exists)
+    }
 }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -60,6 +60,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.significanthobbies.app
         PRODUCT_NAME: Significant Hobbies
+        CODE_SIGN_ENTITLEMENTS: Sources/SignificantHobbies/SignificantHobbies.entitlements
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SUPPORTS_MACCATALYST: NO
   SignificantHobbiesCoreTests:

--- a/openspec/changes/add-native-ios-app/design.md
+++ b/openspec/changes/add-native-ios-app/design.md
@@ -35,6 +35,10 @@ Journal types expose no public field. Only explicitly eligible Living items have
 
 `ASWebAuthenticationSession` uses an exact `significanthobbies://auth` callback and a one-use, five-minute handoff; URLSession uses an isolated revisioned JSON endpoint; bearer session material lives only in Keychain. Local changes queue sync intents and expose pending, synced, conflict, and error states. Deferred conflicts freeze cloud writes until the owner decides. No service secrets or environment files ship in the app, and the additive migration remains unapplied until production review.
 
+### Apple identity is native and account linking is explicit
+
+The iPhone app obtains an Apple identity token with AuthenticationServices and a SHA-256 nonce, then sends it directly to Better Auth for signature, issuer, audience, expiry, and nonce validation against `com.significanthobbies.app`. A new Apple identity may create an account. An existing Google account can add Apple only while already authenticated through an explicit link action. Matching email addresses never silently merge accounts, and a hidden Apple relay address is accepted when the owner deliberately links it.
+
 ### Preserve-mode Life Atlas adaptation
 
 The native app inherits `DESIGN.md`: warm paper, olive ink, atlas gold, lived sage, open spatial fields, paths, waypoints, and almanac chronology. Live More/Daily/See History is the tab order. Native navigation, sheets, Dynamic Type, VoiceOver, and Reduce Motion remain authoritative. Equal card grids, shame loops, and generic productivity dashboards remain excluded.

--- a/openspec/changes/add-native-ios-app/proposal.md
+++ b/openspec/changes/add-native-ios-app/proposal.md
@@ -7,6 +7,7 @@ Significant Hobbies is a daily life-practice product whose most frequent moments
 - Add a first-party SwiftUI iPhone application using Apple frameworks and no new production dependencies.
 - Match the current authenticated product surface: morning and evening Daily rituals, new-thing capture, hobbies, commitments, timelines, bucket lists, quests, journal context, history, trajectory, profile, settings, export, deletion, and opt-in public sharing controls.
 - Preserve private-by-default local behavior and add an isolated, revisioned private-atlas service contract without mutating existing public web tables.
+- Offer Sign in with Apple beside Google, with explicit linking for an already connected account and no email-based implicit account merge.
 - Adapt the established Life Atlas visual language to native navigation, controls, accessibility, and motion.
 - Add native tests, privacy metadata, app metadata, icons, simulator verification, and a signed archive workflow that stops before upload.
 - Keep the web application intact, preserve the mortality-aware framing, and do not introduce a unified hub.
@@ -23,4 +24,4 @@ None.
 
 ## Impact
 
-Adds an `ios/` Swift/Xcode surface beside the existing web application plus additive native handoff/state source and an unapplied D1 migration. Existing public pages and web data formats remain unchanged; production activation stays a separately reviewed manual gate. The iOS app uses the personal Apple development team for local signing and produces no App Store Connect records or uploads in this change.
+Adds an `ios/` Swift/Xcode surface beside the existing web application plus additive native handoff/state source, native Apple identity-token validation, and an additive D1 migration. Existing public pages and web data formats remain unchanged. The iOS app uses the personal Apple development team for signing and is prepared for a separately authorized TestFlight upload.

--- a/openspec/changes/add-native-ios-app/specs/native-ios-client/spec.md
+++ b/openspec/changes/add-native-ios-app/specs/native-ios-client/spec.md
@@ -46,6 +46,13 @@ When connected through existing Significant Hobbies service contracts, the clien
 - **WHEN** the user explicitly makes one eligible commitment public
 - **THEN** only that item becomes publication-eligible and unrelated private data remains private
 
+### Requirement: Native account access includes Sign in with Apple
+The iOS client SHALL offer Sign in with Apple beside Google account connection. Apple identity tokens SHALL be verified by the service for the native bundle identifier. The service SHALL disable implicit email-based linking; an existing signed-in account MAY add Apple only through an explicit authenticated linking action.
+
+#### Scenario: Existing Google user adds Apple
+- **WHEN** an authenticated Google user chooses the Apple control and completes Apple's authorization
+- **THEN** Apple is linked to that same account without replacing the private Life Atlas or inferring identity from matching email text
+
 ### Requirement: Profile and data control have parity
 The iOS client SHALL provide profile editing, privacy settings, public-profile preview, soundtrack preference where supported, export, local reset, sign out, and account deletion with confirmation and recovery copy.
 

--- a/openspec/changes/add-native-ios-app/tasks.md
+++ b/openspec/changes/add-native-ios-app/tasks.md
@@ -24,3 +24,9 @@
 - [x] 4.3 Add release metadata, privacy/support copy, simulator screenshots, and documented device-only checks
 - [x] 4.4 Run strict OpenSpec validation, tests, Release simulator build, personal-team archive, and signature verification without upload
 - [ ] 4.5 Apply the reviewed additive D1 migration and deploy the exact native callback/API contract before live account testing
+
+## 5. Equivalent Native Account Access
+
+- [x] 5.1 Add the Apple entitlement, nonce-backed AuthenticationServices UI, native token exchange, provider visibility, and explicit Apple linking
+- [x] 5.2 Configure Better Auth for native Apple token validation with disabled implicit linking and no browser-only Apple secret requirement
+- [x] 5.3 Add account/auth tests, run the complete native and web checks, archive with the personal team, and update App Store metadata

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -41,6 +41,7 @@ const baseURL =
   (testAuthEnabled ? 'http://localhost:3000' : 'https://significanthobbies.com');
 const googleClientId = process.env.GOOGLE_CLIENT_ID?.trim();
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim();
+const appleBundleIdentifier = process.env.APPLE_APP_BUNDLE_IDENTIFIER?.trim();
 
 export const auth = betterAuth({
   secret: authSecret,
@@ -49,17 +50,35 @@ export const auth = betterAuth({
     provider: 'sqlite',
     schema: { user, session, account, verification },
   }),
-  socialProviders:
-    googleClientId && googleClientSecret
+  socialProviders: {
+    ...(googleClientId && googleClientSecret
       ? { google: { clientId: googleClientId, clientSecret: googleClientSecret } }
-      : {},
+      : {}),
+    ...(appleBundleIdentifier
+      ? {
+          apple: {
+            clientId: appleBundleIdentifier,
+            clientSecret: '',
+            appBundleIdentifier: appleBundleIdentifier,
+          },
+        }
+      : {}),
+  },
+  account: {
+    accountLinking: {
+      enabled: true,
+      disableImplicitLinking: true,
+      trustedProviders: ['google', 'apple'],
+      allowDifferentEmails: true,
+    },
+  },
   // Off in production. See the comment on `testAuthEnabled` above.
   emailAndPassword: { enabled: testAuthEnabled },
   user: {
     deleteUser: { enabled: true },
   },
   plugins: [bearer()],
-  trustedOrigins: [baseURL, 'significanthobbies://auth'],
+  trustedOrigins: [baseURL, 'https://appleid.apple.com', 'significanthobbies://auth'],
   databaseHooks: {
     user: {
       create: {

--- a/src/lib/native-account.test.ts
+++ b/src/lib/native-account.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -34,5 +36,22 @@ describe('native account boundary', () => {
     expect(
       parseNativeStateEnvelope({ document: { schemaVersion: 1 }, baseRevision: -1 })
     ).toBeNull();
+  });
+
+  it('validates native Apple identity and never links by email implicitly', async () => {
+    const [auth, client] = await Promise.all([
+      readFile(resolve(process.cwd(), 'src/lib/auth.ts'), 'utf8'),
+      readFile(
+        resolve(process.cwd(), 'ios/Sources/SignificantHobbies/NativeAccountClient.swift'),
+        'utf8'
+      ),
+    ]);
+
+    expect(auth).toMatch(/appBundleIdentifier:\s*appleBundleIdentifier/);
+    expect(auth).toMatch(/disableImplicitLinking:\s*true/);
+    expect(auth).toMatch(/allowDifferentEmails:\s*true/);
+    expect(client).toMatch(/\/api\/auth\/sign-in\/social/);
+    expect(client).toMatch(/\/api\/auth\/link-social/);
+    expect(client).toMatch(/set-auth-token/);
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,6 +22,7 @@ cpu_ms = 30000
 
 [vars]
 NODE_ENV = "production"
+APPLE_APP_BUNDLE_IDENTIFIER = "com.significanthobbies.app"
 
 # ─── Workers AI binding (Lumi coach) ─────────────────────────────────────
 # Free tier, no API key needed. Used by the AI-powered weekly review.
@@ -65,3 +66,4 @@ cpu_ms = 30000
 
 [env.preview.vars]
 NODE_ENV = "production"
+APPLE_APP_BUNDLE_IDENTIFIER = "com.significanthobbies.app"


### PR DESCRIPTION
Adds nonce-backed Sign in with Apple, explicit provider linking, personal-team entitlements, Better Auth native-token validation, and regression coverage. Existing Google accounts link Apple only while authenticated; implicit email linking remains disabled.\n\nCloses #78