### PR TITLE
Return exact stable MCP timeline totals

### DIFF
--- a/src/app/api/mcp/timelines/route.test.ts
+++ b/src/app/api/mcp/timelines/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  total: 10,
+  rows: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('~/server/db', () => ({
+  db: {
+    select(selection: Record<string, unknown>) {
+      if ('value' in selection) {
+        return {
+          from: () => ({ where: async () => [{ value: state.total }] }),
+        };
+      }
+      return {
+        from: () => ({
+          leftJoin: () => ({
+            where: () => ({
+              orderBy: () => ({
+                limit: () => ({ offset: async () => state.rows }),
+              }),
+            }),
+          }),
+        }),
+      };
+    },
+  },
+}));
+
+import { GET } from './route';
+
+function timeline(id: number) {
+  return {
+    id: `timeline-${id}`,
+    title: `Timeline ${id}`,
+    visibility: 'PUBLIC',
+    slug: `timeline-${id}`,
+    phases: '[]',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date(`2026-01-${String(id).padStart(2, '0')}T00:00:00.000Z`),
+    userName: 'Owner',
+    userUsername: 'owner',
+  };
+}
+
+async function page(offset: number) {
+  const response = await GET(
+    new Request(`https://significanthobbies.com/api/mcp/timelines?limit=2&offset=${offset}`)
+  );
+  return response.json() as Promise<{
+    items: Array<{ id: string }>;
+    total: number;
+    nextOffset: number | null;
+  }>;
+}
+
+describe('public timeline MCP pagination', () => {
+  beforeEach(() => {
+    state.total = 10;
+    state.rows = [];
+  });
+
+  it('keeps the exact total stable across first, middle, and terminal pages', async () => {
+    state.rows = [timeline(1), timeline(2)];
+    const first = await page(0);
+    state.rows = [timeline(5), timeline(6)];
+    const middle = await page(4);
+    state.rows = [timeline(9), timeline(10)];
+    const terminal = await page(8);
+
+    expect(first).toMatchObject({ total: 10, nextOffset: 2 });
+    expect(middle).toMatchObject({ total: 10, nextOffset: 6 });
+    expect(terminal).toMatchObject({ total: 10, nextOffset: null });
+    expect(
+      new Set([...first.items, ...middle.items, ...terminal.items].map((item) => item.id)).size
+    ).toBe(6);
+  });
+});

--- a/src/app/api/mcp/timelines/route.ts
+++ b/src/app/api/mcp/timelines/route.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, like } from 'drizzle-orm';
+import { and, count, desc, eq, like } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 import { timelines, users } from '~/db/schema';
@@ -12,33 +12,34 @@ export async function GET(request: Request) {
   const where = q
     ? and(eq(timelines.visibility, 'PUBLIC'), like(timelines.title, `%${q}%`))
     : eq(timelines.visibility, 'PUBLIC');
-  const rows = await db
-    .select({
-      id: timelines.id,
-      title: timelines.title,
-      visibility: timelines.visibility,
-      slug: timelines.slug,
-      phases: timelines.phases,
-      createdAt: timelines.createdAt,
-      updatedAt: timelines.updatedAt,
-      userName: users.name,
-      userUsername: users.username,
-    })
-    .from(timelines)
-    .leftJoin(users, eq(timelines.userId, users.id))
-    .where(where)
-    .orderBy(desc(timelines.updatedAt))
-    .limit(limit + 1)
-    .offset(offset);
-  const hasMore = rows.length > limit;
-  const items = rows
-    .slice(0, limit)
-    .map(publicTimelineRecord)
-    .filter((item) => item !== null);
+  const [rows, totals] = await Promise.all([
+    db
+      .select({
+        id: timelines.id,
+        title: timelines.title,
+        visibility: timelines.visibility,
+        slug: timelines.slug,
+        phases: timelines.phases,
+        createdAt: timelines.createdAt,
+        updatedAt: timelines.updatedAt,
+        userName: users.name,
+        userUsername: users.username,
+      })
+      .from(timelines)
+      .leftJoin(users, eq(timelines.userId, users.id))
+      .where(where)
+      .orderBy(desc(timelines.updatedAt), desc(timelines.id))
+      .limit(limit)
+      .offset(offset),
+    db.select({ value: count() }).from(timelines).where(where),
+  ]);
+  const total = totals[0]?.value ?? 0;
+  const items = rows.map(publicTimelineRecord).filter((item) => item !== null);
+  const nextOffset = offset + items.length < total ? offset + items.length : null;
   return NextResponse.json({
     generatedAt: new Date().toISOString(),
     items,
-    total: offset + items.length + (hasMore ? 1 : 0),
-    nextOffset: hasMore ? offset + items.length : null,
+    total,
+    nextOffset,
   });
 }


### PR DESCRIPTION
## What changed

- count PUBLIC timelines with the same optional search filter as the page query
- return one exact `total` on every page
- use a deterministic updated-time plus ID ordering
- cover first, middle, and terminal pages with a regression test

## Root cause

The route exposed a lower-bound estimate (`offset + items.length + 1`) as `total`, so the value grew as clients paginated.

## Impact

MCP clients can calculate terminal offsets and follow continuation metadata without contradictory totals.

## Validation

- `pnpm test` — 483 passed
- `pnpm typecheck`
- `pnpm lint` (push hook)

Closes #91
