### PR TITLE
perf: cache bucket-list suggestion tokens

### DIFF
--- a/codevetter.performance.json
+++ b/codevetter.performance.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "codevetter-performance-flows/v1",
+  "flows": [
+    {
+      "sources": ["src/lib/bucket-list-insights.ts"],
+      "performance": {
+        "adapter": "vitest",
+        "target": "src/lib/bucket-list-insights.performance.test.ts",
+        "name": "scales across existing bucket-list sizes"
+      },
+      "correctness": {
+        "adapter": "vitest",
+        "target": "src/lib/bucket-list-insights.test.ts",
+        "name": "is deterministic for the same inputs and seed"
+      }
+    }
+  ]
+}

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -39,6 +39,14 @@ The pure modules (`commitments.ts`, `mortality.ts`, `personality.ts`,
 are the highest-value test targets — they have no DB/auth dependencies and
 are the core product logic.
 
+## Performance flow contract
+
+[`codevetter.performance.json`](../../codevetter.performance.json) binds the
+exact bucket-list suggestion scale workload to its deterministic output test.
+CodeVetter uses that snapshot-bound relationship for local incumbent-versus-candidate
+acceptance; it does not replace `pnpm test` or make a production-performance
+claim.
+
 ## Native tests — XCTest
 
 `pnpm quality:native` selects an available iPhone simulator, regenerates the

--- a/src/lib/bucket-list-insights.performance.test.ts
+++ b/src/lib/bucket-list-insights.performance.test.ts
@@ -1,0 +1,34 @@
+import { performance } from 'node:perf_hooks';
+
+import { describe, expect, it } from 'vitest';
+
+import { getBucketListSuggestions } from './bucket-list-insights';
+
+const EXISTING_ITEM_COUNTS = [0, 10, 50];
+const ITERATIONS = 10;
+
+describe('bucket-list suggestion performance', () => {
+  it('scales across existing bucket-list sizes', () => {
+    const fixture = getBucketListSuggestions([], 50, 99).map((suggestion) => ({
+      title: suggestion.title,
+      category: suggestion.category,
+    }));
+    const metrics: string[] = [];
+
+    for (const size of EXISTING_ITEM_COUNTS) {
+      const existingItems = fixture.slice(0, size);
+      expect(getBucketListSuggestions(existingItems, 6, 0)).toHaveLength(6);
+
+      let duration = 0;
+      for (let iteration = 0; iteration < ITERATIONS; iteration += 1) {
+        const startedAt = performance.now();
+        const suggestions = getBucketListSuggestions(existingItems, 6, iteration);
+        duration += performance.now() - startedAt;
+        expect(suggestions).toHaveLength(6);
+      }
+      metrics.push(`size${size}=${(duration / ITERATIONS).toFixed(3)}ms/op`);
+    }
+
+    console.log(`[benchmark] ${metrics.join(' ')} (${ITERATIONS} iterations)`);
+  });
+});

--- a/src/lib/bucket-list-insights.ts
+++ b/src/lib/bucket-list-insights.ts
@@ -277,10 +277,10 @@ function tokenize(title: string): Set<string> {
   );
 }
 
+const SUGGESTION_TOKENS = SUGGESTION_POOL.map((suggestion) => tokenize(suggestion.title));
+
 // Jaccard similarity over meaningful tokens. Returns 0–1.
-function titleSimilarity(a: string, b: string): number {
-  const ta = tokenize(a);
-  const tb = tokenize(b);
+function tokenSimilarity(ta: ReadonlySet<string>, tb: ReadonlySet<string>): number {
   if (ta.size === 0 || tb.size === 0) return 0;
   let inter = 0;
   for (const t of ta) if (tb.has(t)) inter++;
@@ -316,13 +316,15 @@ export function getBucketListSuggestions(
   seed = 0
 ): SuggestionItem[] {
   const existingCats = new Set(existingItems.map((i) => i.category).filter(Boolean));
+  const existingTokens = existingItems.map((item) => tokenize(item.title));
 
   // Filter out items too similar to one the user already has (Jaccard ≥ 0.5
   // over meaningful tokens). Catches "Run a marathon" vs "Run a half marathon"
   // while letting genuinely different suggestions through.
-  const pool = SUGGESTION_POOL.filter(
-    (s) => !existingItems.some((e) => titleSimilarity(s.title, e.title) >= 0.5)
-  );
+  const pool = SUGGESTION_POOL.filter((_suggestion, index) => {
+    const tokens = SUGGESTION_TOKENS[index]!;
+    return !existingTokens.some((existing) => tokenSimilarity(tokens, existing) >= 0.5);
+  });
 
   // Separate into "gap categories" (user has none) vs "familiar" (user has some)
   const gaps = pool.filter((s) => !existingCats.has(s.category));
@@ -334,11 +336,15 @@ export function getBucketListSuggestions(
     .sort()
     .join('|');
   const rng = mulberry32(hashString(existingKey) + seed);
-  const shuffle = <T>(arr: T[]): T[] =>
-    [...arr]
-      .map((v) => ({ v, k: rng() }))
-      .sort((a, b) => a.k - b.k)
-      .map(({ v }) => v);
+  const shuffle = <T>(arr: T[]): T[] => {
+    const keys = new Float64Array(arr.length);
+    const indices = Array.from({ length: arr.length }, (_, index) => {
+      keys[index] = rng();
+      return index;
+    });
+    indices.sort((a, b) => keys[a]! - keys[b]!);
+    return indices.map((index) => arr[index]!);
+  };
 
   // Half from categories the user has nothing in, half from ones they do.
   const gapCount = Math.min(Math.ceil(count / 2), gaps.length);


### PR DESCRIPTION
## Summary

- precompute suggestion-title tokens and tokenize existing items once per request
- reduce shuffle allocation overhead while preserving seeded determinism
- add an explicit CodeVetter performance-flow contract and representative-scale test

## Validation

- pnpm test (484 tests)
- format, lint, and root typecheck passed
- local pnpm quality stopped at an existing landing-Astro Vite 6/Vite 8 plugin type mismatch; this change does not touch landing dependencies or config

Closes #93