### PR TITLE
Fix sitemap canonical parity

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: 'About — Significant Hobbies',
   description:
     'Significant Hobbies turns your hobby history into a shareable timeline. Quiz-based recommendations, gamified discovery, and a public profile.',
+  alternates: { canonical: 'https://significanthobbies.com/about' },
 };
 
 export default function AboutPage() {

--- a/src/app/cheap-hobbies/page.tsx
+++ b/src/app/cheap-hobbies/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
   title: '25 Free & Cheap Hobbies That Are Actually Fun | SignificantHobbies',
   description:
     '25 free and cheap hobbies that are genuinely worth your time. 15 completely free + 10 under $50 to start. With honest cost breakdowns.',
+  alternates: { canonical: 'https://significanthobbies.com/cheap-hobbies' },
 };
 
 function hobbySlug(name: string) {

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   title: 'Compare Hobbies Side by Side — SignificantHobbies',
   description:
     "Can't decide between two hobbies? Compare them on cost, time commitment, social level, difficulty, and more. Make an informed choice about your next hobby.",
+  alternates: { canonical: 'https://significanthobbies.com/compare' },
 };
 
 export default function ComparePage() {

--- a/src/app/get-started/page.tsx
+++ b/src/app/get-started/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: 'Get Your Username — SignificantHobbies',
   description:
     'Choose your unique username on SignificantHobbies. Get your own profile at significanthobbies.com/u/yourname and start sharing your hobby journey.',
+  alternates: { canonical: 'https://significanthobbies.com/get-started' },
 };
 
 export default function GetStartedPage() {

--- a/src/app/hobbies-for-adults/page.tsx
+++ b/src/app/hobbies-for-adults/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
   title: '50 Best Hobbies for Adults — Find What Excites You | SignificantHobbies',
   description:
     'Discover 50 hobbies perfect for adults. From creative pursuits to physical adventures, find your next passion with our curated guide.',
+  alternates: { canonical: 'https://significanthobbies.com/hobbies-for-adults' },
 };
 
 function hobbySlug(name: string) {

--- a/src/app/hobbies-for-mental-health/page.tsx
+++ b/src/app/hobbies-for-mental-health/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
   title: '15 Hobbies That Improve Mental Health — Science-Backed | SignificantHobbies',
   description:
     'Discover 15 science-backed hobbies that genuinely improve mental health — from yoga and running to gardening and writing. Learn why each one works.',
+  alternates: { canonical: 'https://significanthobbies.com/hobbies-for-mental-health' },
 };
 
 function hobbySlug(name: string) {

--- a/src/app/hobbies-for-resume/page.tsx
+++ b/src/app/hobbies-for-resume/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
   title: '30 Impressive Hobbies to Put on Your Resume | SignificantHobbies',
   description:
     'Learn which hobbies to include on your resume and why. 30 hobbies organized by what they signal to employers — leadership, creativity, discipline, and more.',
+  alternates: { canonical: 'https://significanthobbies.com/hobbies-for-resume' },
 };
 
 function hobbySlug(name: string) {

--- a/src/app/hobbies-to-try/page.tsx
+++ b/src/app/hobbies-to-try/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
   title: '40 New Hobbies to Try in 2026 — From Beginner-Friendly to Bold | SignificantHobbies',
   description:
     '40 hobbies to try in 2026, organized by how much effort they take to start. From tonight with no equipment to deep year-long commitments.',
+  alternates: { canonical: 'https://significanthobbies.com/hobbies-to-try' },
 };
 
 function hobbySlug(name: string) {

--- a/src/app/hobbies/category/[category]/page.tsx
+++ b/src/app/hobbies/category/[category]/page.tsx
@@ -66,6 +66,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${cat.name} Hobbies — SignificantHobbies`,
     description: `Explore ${cat.hobbies.length} ${cat.name.toLowerCase()} hobbies. Browse community timelines, find tools, and discover your next ${cat.name.toLowerCase()} passion.`,
+    alternates: { canonical: `https://significanthobbies.com/hobbies/category/${slug}` },
   };
 }
 

--- a/src/app/hobbies/random/layout.tsx
+++ b/src/app/hobbies/random/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  alternates: { canonical: 'https://significanthobbies.com/hobbies/random' },
+};
+
+export default function RandomHobbyLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -79,9 +79,6 @@ export const metadata: Metadata = {
       },
     ],
   },
-  alternates: {
-    canonical: 'https://significanthobbies.com',
-  },
   metadataBase: new URL('https://significanthobbies.com'),
   twitter: {
     card: 'summary_large_image',

--- a/src/app/manifesto/page.tsx
+++ b/src/app/manifesto/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: 'Manifesto — SignificantHobbies',
   description:
     'Life is finite. We build tools to help you spend your remaining weeks on what matters — hobbies, bucket lists, and side quests.',
+  alternates: { canonical: 'https://significanthobbies.com/manifesto' },
 };
 
 export default function ManifestoPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,8 +17,10 @@ import { db } from '~/server/db';
 export const dynamic = 'force-dynamic';
 
 export const metadata = {
-  title: `Dashboard — ${BRAND_NAME}`,
-  robots: { index: false, follow: false },
+  title: `${BRAND_NAME} — Your Hobby Journey`,
+  description:
+    'Map your hobby history across life phases. Discover what rekindled, what persisted, and what to explore next.',
+  alternates: { canonical: 'https://significanthobbies.com' },
 };
 
 export default async function HomePage() {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -6,6 +6,7 @@ import { FadeIn, GridBackground, SpotlightCard } from '~/components/aceternity';
 export const metadata: Metadata = {
   title: 'Privacy — Significant Hobbies',
   description: "Short and clear: what we store, what we don't, and how to delete.",
+  alternates: { canonical: 'https://significanthobbies.com/privacy' },
 };
 
 export default function PrivacyPage() {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -17,7 +17,10 @@ import { db } from '~/server/db';
 
 import { SearchPageClient } from './search-client';
 
-export const metadata = { title: 'Search — SignificantHobbies' };
+export const metadata = {
+  title: 'Search — SignificantHobbies',
+  alternates: { canonical: 'https://significanthobbies.com/search' },
+};
 
 interface Props {
   searchParams: Promise<{ q?: string }>;

--- a/src/app/side-quests/page.tsx
+++ b/src/app/side-quests/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: 'Side Quests — SignificantHobbies',
   description:
     '50 curated micro-adventures to make life more interesting. Roll a random quest, get a personalized pick, or take on the full board.',
+  alternates: { canonical: 'https://significanthobbies.com/side-quests' },
 };
 
 export default function SideQuestsPage() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -296,24 +296,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.6,
     },
     {
-      url: `${baseUrl}/llms.txt`,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 0.4,
-    },
-    {
-      url: `${baseUrl}/llms-full.txt`,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 0.4,
-    },
-    {
-      url: `${baseUrl}/index.md`,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 0.4,
-    },
-    {
       url: `${baseUrl}/side-quests`,
       lastModified: now,
       changeFrequency: 'monthly',

--- a/src/app/starter-kits/page.tsx
+++ b/src/app/starter-kits/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
   title: 'Local Hobby Starter Kits - SignificantHobbies',
   description:
     'Beginner-friendly hobby starter kits you can run with local materials, small budgets, and one clear first experiment.',
+  alternates: { canonical: 'https://significanthobbies.com/starter-kits' },
 };
 
 const CATEGORY_STYLES: Record<string, string> = {

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -5,6 +5,7 @@ import { FadeIn, GridBackground, SpotlightCard } from '~/components/aceternity';
 export const metadata = {
   title: 'Terms — Significant Hobbies',
   description: 'Use of Significant Hobbies is provided as-is.',
+  alternates: { canonical: 'https://significanthobbies.com/terms' },
 };
 
 export default function TermsPage() {

--- a/src/app/tools/cost-calculator/page.tsx
+++ b/src/app/tools/cost-calculator/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: 'Hobby Cost Calculator — SignificantHobbies',
   description:
     'Add up the real first-year cost of any hobby — equipment, lessons, subscriptions, supplies — before you commit. Saves to your browser; nothing uploaded.',
+  alternates: { canonical: 'https://significanthobbies.com/tools/cost-calculator' },
 };
 
 export default function CostCalculatorPage() {

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
   title: 'Hobby Tools — SignificantHobbies',
   description:
     'Free tools to help you discover, plan, and commit to hobbies. Hobby quiz, time calculator, hobby comparison, and more.',
+  alternates: { canonical: 'https://significanthobbies.com/tools' },
 };
 
 interface Tool {

--- a/src/app/tools/time-calculator/page.tsx
+++ b/src/app/tools/time-calculator/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: 'Hobby Time Calculator — How Much Free Time Do You Have? | SignificantHobbies',
   description:
     "Calculate how much free time you actually have for hobbies each week. Input your schedule and discover hidden hours you didn't know existed.",
+  alternates: { canonical: 'https://significanthobbies.com/tools/time-calculator' },
 };
 
 export default function TimeCalculatorPage() {

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -39,6 +39,7 @@ export async function generateMetadata({ params }: Props) {
   return {
     title,
     description,
+    alternates: { canonical: `/u/${username}` },
     openGraph: {
       type: 'profile' as const,
       title,

--- a/src/app/what-are-significant-hobbies/page.tsx
+++ b/src/app/what-are-significant-hobbies/page.tsx
@@ -19,6 +19,7 @@ export const metadata: Metadata = {
     title: 'What Are Significant Hobbies?',
     description: 'The interests that shape who you are across life phases.',
   },
+  alternates: { canonical: 'https://significanthobbies.com/what-are-significant-hobbies' },
 };
 
 const ARCHETYPES = [

--- a/src/lib/sitemap-canonical-contract.test.ts
+++ b/src/lib/sitemap-canonical-contract.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const readSource = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+const sitemapSource = readSource('src/app/sitemap.ts');
+
+function staticSitemapRoutes() {
+  return [...sitemapSource.matchAll(/url: `\$\{baseUrl\}(\/[^`$]+)`/g)].map((match) => match[1]);
+}
+
+describe('sitemap canonical contract', () => {
+  it('keeps machine-readable discovery resources out of the HTML sitemap', () => {
+    for (const resource of ['/llms.txt', '/llms-full.txt', '/index.md']) {
+      expect(sitemapSource).not.toContain(`url: \`\${baseUrl}${resource}\``);
+    }
+  });
+
+  it('gives every literal HTML sitemap route an explicit canonical', () => {
+    for (const route of staticSitemapRoutes()) {
+      const routeDirectory = join('src/app', route.slice(1));
+      const metadataSources = ['page.tsx', 'layout.tsx']
+        .map((file) => join(routeDirectory, file))
+        .filter((file) => existsSync(file))
+        .map(readSource)
+        .join('\n');
+
+      expect(metadataSources, `${route} must resolve to an App Router page`).not.toBe('');
+      expect(metadataSources, `${route} must declare its own canonical`).toMatch(/canonical\s*:/);
+    }
+  });
+
+  it('covers the root and dynamic sitemap route families', () => {
+    const homeSource = readSource('src/app/page.tsx');
+    expect(homeSource).toContain("canonical: 'https://significanthobbies.com'");
+    expect(homeSource).not.toMatch(/robots\s*:\s*\{\s*index:\s*false/);
+
+    for (const routeSource of [
+      'src/app/hobbies/category/[category]/page.tsx',
+      'src/app/u/[username]/page.tsx',
+    ]) {
+      expect(readSource(routeSource), `${routeSource} must declare a dynamic canonical`).toMatch(
+        /canonical\s*:/
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes #97

- remove inherited homepage canonical from child routes
- make the public homepage indexable with accurate metadata
- add self-canonicals to sitemap-listed static, category, and profile routes
- keep non-HTML discovery resources out of the XML sitemap
- add a sitemap/canonical contract test

Validated with targeted contract tests, the full 487-test suite, TypeScript, Biome, and a production Next.js build.