### PR TITLE
chore: reduce accepted code-health debt

### DIFF
--- a/scripts/check-code-health.mjs
+++ b/scripts/check-code-health.mjs
@@ -13,15 +13,15 @@ const productionPaths = ['src', 'ios/Sources', 'scripts'];
 
 const baselines = {
   complexity: {
-    violations: 85,
+    violations: 82,
     maxCcn: 46,
     maxLength: 741,
     maxParams: 12,
   },
   duplication: {
-    clones: 52,
-    duplicatedLines: 945,
-    percentage: 1.6015863331299574,
+    clones: 50,
+    duplicatedLines: 771,
+    percentage: 1.308154331670569,
   },
   unused: {
     files: 0,

--- a/src/app/timeline/[id]/opengraph-image.tsx
+++ b/src/app/timeline/[id]/opengraph-image.tsx
@@ -1,36 +1,20 @@
 import { eq } from 'drizzle-orm';
-import { ImageResponse } from 'next/og';
 
 import { timelines, users } from '~/db/schema';
 import { computePersonality } from '~/lib/personality';
+import {
+  fallbackTimelineImage,
+  renderTimelineOgImage,
+  timelineOgImageContentType,
+  timelineOgImageSize,
+} from '~/lib/timeline-og-image';
 import type { Phase } from '~/lib/types';
 import { parseJSONColumn } from '~/lib/utils';
 import { db } from '~/server/db';
 
 export const runtime = 'nodejs';
-export const size = { width: 1200, height: 630 };
-export const contentType = 'image/png';
-
-function fallbackImage(message: string) {
-  return new ImageResponse(
-    <div
-      style={{
-        background: '#FEFDF8',
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: 40,
-        fontFamily: 'system-ui, sans-serif',
-        color: '#78716C',
-      }}
-    >
-      {message}
-    </div>,
-    { width: 1200, height: 630 }
-  );
-}
+export const size = timelineOgImageSize;
+export const contentType = timelineOgImageContentType;
 
 export default async function OgImage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -42,15 +26,15 @@ export default async function OgImage({ params }: { params: Promise<{ id: string
     });
   } catch (err) {
     console.error('opengraph-image: timeline lookup failed', err);
-    return fallbackImage('Significant Hobbies');
+    return fallbackTimelineImage('Significant Hobbies');
   }
 
-  if (!timeline) return fallbackImage('Timeline not found');
+  if (!timeline) return fallbackTimelineImage('Timeline not found');
 
   // Never render private timeline content on this unauthenticated endpoint
   // (link unfurlers fetch it without cookies and cache the result).
   if (timeline.visibility === 'PRIVATE') {
-    return fallbackImage('Significant Hobbies');
+    return fallbackTimelineImage('Significant Hobbies');
   }
 
   let timelineUser: { name: string | null; username: string | null } | null = null;
@@ -73,136 +57,11 @@ export default async function OgImage({ params }: { params: Promise<{ id: string
   const personality = computePersonality(phases);
   const archetype = personality.archetype;
 
-  return new ImageResponse(
-    <div
-      style={{
-        background: 'linear-gradient(135deg, #FEFDF8 0%, #ECFDF5 60%, #FFF8EE 100%)',
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '60px 80px',
-        fontFamily: 'system-ui, sans-serif',
-      }}
-    >
-      {/* Header row */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          marginBottom: 40,
-        }}
-      >
-        <div style={{ fontSize: 22, color: '#059669', fontWeight: 700 }}>
-          significanthobbies.com
-        </div>
-        {timelineUser?.username && (
-          <div style={{ fontSize: 22, color: '#78716C' }}>@{timelineUser.username}</div>
-        )}
-      </div>
-
-      {/* Timeline title */}
-      <div
-        style={{
-          fontSize: 52,
-          fontWeight: 800,
-          color: '#1C1917',
-          lineHeight: 1.2,
-          marginBottom: 24,
-          maxWidth: 800,
-        }}
-      >
-        {timeline.title ?? 'Hobby Timeline'}
-      </div>
-
-      {/* Personality archetype badge */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          marginBottom: 32,
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            padding: '14px 28px',
-            borderRadius: 16,
-            background: 'linear-gradient(135deg, #D1FAE5 0%, #FEF3C7 100%)',
-            border: '2px solid #A7F3D0',
-          }}
-        >
-          <span style={{ fontSize: 32 }}>{archetype.emoji}</span>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <span
-              style={{
-                fontSize: 13,
-                color: '#6B7280',
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: 1,
-              }}
-            >
-              Personality
-            </span>
-            <span style={{ fontSize: 24, color: '#1C1917', fontWeight: 800 }}>
-              {archetype.name}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {/* Stats */}
-      <div style={{ display: 'flex', gap: 16, marginBottom: 40 }}>
-        <div
-          style={{
-            padding: '12px 24px',
-            borderRadius: 12,
-            background: '#ECFDF5',
-            color: '#059669',
-            fontSize: 20,
-            fontWeight: 700,
-          }}
-        >
-          {phases.length} phase{phases.length !== 1 ? 's' : ''}
-        </div>
-        <div
-          style={{
-            padding: '12px 24px',
-            borderRadius: 12,
-            background: '#FEF3C7',
-            color: '#D97706',
-            fontSize: 20,
-            fontWeight: 700,
-          }}
-        >
-          {totalHobbies} hobb{totalHobbies !== 1 ? 'ies' : 'y'}
-        </div>
-      </div>
-
-      {/* Phase labels */}
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        {phases.slice(0, 5).map((p, i) => (
-          <div
-            key={p.id}
-            style={{
-              padding: '10px 20px',
-              borderRadius: 24,
-              background: `hsl(${160 - i * 25}, 60%, 90%)`,
-              color: `hsl(${160 - i * 25}, 60%, 30%)`,
-              fontSize: 20,
-              fontWeight: 600,
-            }}
-          >
-            {p.label}
-          </div>
-        ))}
-      </div>
-    </div>,
-    { width: 1200, height: 630 }
-  );
+  return renderTimelineOgImage({
+    title: timeline.title,
+    username: timelineUser?.username ?? null,
+    phases,
+    totalHobbies,
+    archetype,
+  });
 }

--- a/src/app/u/[username]/[slug]/opengraph-image.tsx
+++ b/src/app/u/[username]/[slug]/opengraph-image.tsx
@@ -1,36 +1,20 @@
 import { eq } from 'drizzle-orm';
-import { ImageResponse } from 'next/og';
 
 import { timelines, users } from '~/db/schema';
 import { computePersonality } from '~/lib/personality';
+import {
+  fallbackTimelineImage,
+  renderTimelineOgImage,
+  timelineOgImageContentType,
+  timelineOgImageSize,
+} from '~/lib/timeline-og-image';
 import type { Phase } from '~/lib/types';
 import { parseJSONColumn } from '~/lib/utils';
 import { db } from '~/server/db';
 
 export const runtime = 'nodejs';
-export const size = { width: 1200, height: 630 };
-export const contentType = 'image/png';
-
-function fallbackImage(message: string) {
-  return new ImageResponse(
-    <div
-      style={{
-        background: '#FEFDF8',
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: 40,
-        fontFamily: 'system-ui, sans-serif',
-        color: '#78716C',
-      }}
-    >
-      {message}
-    </div>,
-    { width: 1200, height: 630 }
-  );
-}
+export const size = timelineOgImageSize;
+export const contentType = timelineOgImageContentType;
 
 export default async function OgImage({
   params,
@@ -44,13 +28,13 @@ export default async function OgImage({
   });
 
   if (!timeline) {
-    return fallbackImage('Timeline not found');
+    return fallbackTimelineImage('Timeline not found');
   }
 
   // Never render private timeline content on this unauthenticated endpoint
   // (link unfurlers fetch it without cookies and cache the result).
   if (timeline.visibility === 'PRIVATE') {
-    return fallbackImage('Significant Hobbies');
+    return fallbackTimelineImage('Significant Hobbies');
   }
 
   const timelineUser = timeline.userId
@@ -61,7 +45,7 @@ export default async function OgImage({
     : null;
 
   if (timelineUser?.username !== username) {
-    return fallbackImage('Timeline not found');
+    return fallbackTimelineImage('Timeline not found');
   }
 
   const phases = parseJSONColumn<Phase[]>(timeline.phases, [], 'timeline-slug-og-image:phases');
@@ -71,134 +55,11 @@ export default async function OgImage({
   const personality = computePersonality(phases);
   const archetype = personality.archetype;
 
-  return new ImageResponse(
-    <div
-      style={{
-        background: 'linear-gradient(135deg, #FEFDF8 0%, #ECFDF5 60%, #FFF8EE 100%)',
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '60px 80px',
-        fontFamily: 'system-ui, sans-serif',
-      }}
-    >
-      {/* Header row */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          marginBottom: 40,
-        }}
-      >
-        <div style={{ fontSize: 22, color: '#059669', fontWeight: 700 }}>
-          significanthobbies.com
-        </div>
-        <div style={{ fontSize: 22, color: '#78716C' }}>@{username}</div>
-      </div>
-
-      {/* Timeline title */}
-      <div
-        style={{
-          fontSize: 52,
-          fontWeight: 800,
-          color: '#1C1917',
-          lineHeight: 1.2,
-          marginBottom: 24,
-          maxWidth: 800,
-        }}
-      >
-        {timeline.title ?? 'Hobby Timeline'}
-      </div>
-
-      {/* Personality archetype badge */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          marginBottom: 32,
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            padding: '14px 28px',
-            borderRadius: 16,
-            background: 'linear-gradient(135deg, #D1FAE5 0%, #FEF3C7 100%)',
-            border: '2px solid #A7F3D0',
-          }}
-        >
-          <span style={{ fontSize: 32 }}>{archetype.emoji}</span>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <span
-              style={{
-                fontSize: 13,
-                color: '#6B7280',
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: 1,
-              }}
-            >
-              Personality
-            </span>
-            <span style={{ fontSize: 24, color: '#1C1917', fontWeight: 800 }}>
-              {archetype.name}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {/* Stats */}
-      <div style={{ display: 'flex', gap: 16, marginBottom: 40 }}>
-        <div
-          style={{
-            padding: '12px 24px',
-            borderRadius: 12,
-            background: '#ECFDF5',
-            color: '#059669',
-            fontSize: 20,
-            fontWeight: 700,
-          }}
-        >
-          {phases.length} phase{phases.length !== 1 ? 's' : ''}
-        </div>
-        <div
-          style={{
-            padding: '12px 24px',
-            borderRadius: 12,
-            background: '#FEF3C7',
-            color: '#D97706',
-            fontSize: 20,
-            fontWeight: 700,
-          }}
-        >
-          {totalHobbies} hobb{totalHobbies !== 1 ? 'ies' : 'y'}
-        </div>
-      </div>
-
-      {/* Phase labels */}
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        {phases.slice(0, 5).map((p, i) => (
-          <div
-            key={p.id}
-            style={{
-              padding: '10px 20px',
-              borderRadius: 24,
-              background: `hsl(${160 - i * 25}, 60%, 90%)`,
-              color: `hsl(${160 - i * 25}, 60%, 30%)`,
-              fontSize: 20,
-              fontWeight: 600,
-            }}
-          >
-            {p.label}
-          </div>
-        ))}
-      </div>
-    </div>,
-    { width: 1200, height: 630 }
-  );
+  return renderTimelineOgImage({
+    title: timeline.title,
+    username,
+    phases,
+    totalHobbies,
+    archetype,
+  });
 }

--- a/src/app/u/[username]/opengraph-image.tsx
+++ b/src/app/u/[username]/opengraph-image.tsx
@@ -2,32 +2,53 @@ import { eq } from 'drizzle-orm';
 import { ImageResponse } from 'next/og';
 
 import { timelines, users } from '~/db/schema';
+import {
+  fallbackTimelineImage,
+  timelineOgImageContentType,
+  timelineOgImageSize,
+} from '~/lib/timeline-og-image';
 import type { Phase } from '~/lib/types';
 import { parseJSONColumn } from '~/lib/utils';
 import { db } from '~/server/db';
 
 export const runtime = 'nodejs';
-export const size = { width: 1200, height: 630 };
-export const contentType = 'image/png';
+export const size = timelineOgImageSize;
+export const contentType = timelineOgImageContentType;
 
-function fallbackImage(message: string) {
-  return new ImageResponse(
-    <div
-      style={{
-        background: '#FEFDF8',
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: 40,
-        fontFamily: 'system-ui, sans-serif',
-        color: '#78716C',
-      }}
-    >
-      {message}
-    </div>,
-    { width: 1200, height: 630 }
+function UserProfileOgStats({
+  publicTimelines,
+  hobbyCount,
+}: {
+  publicTimelines: Array<{ phases: string; visibility: string }>;
+  hobbyCount: number;
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 20 }}>
+      <div
+        style={{
+          padding: '12px 28px',
+          borderRadius: 12,
+          background: '#ECFDF5',
+          color: '#059669',
+          fontSize: 22,
+          fontWeight: 700,
+        }}
+      >
+        {publicTimelines.length} timeline{publicTimelines.length !== 1 ? 's' : ''}
+      </div>
+      <div
+        style={{
+          padding: '12px 28px',
+          borderRadius: 12,
+          background: '#FEF3C7',
+          color: '#D97706',
+          fontSize: 22,
+          fontWeight: 700,
+        }}
+      >
+        {hobbyCount} hobb{hobbyCount !== 1 ? 'ies' : 'y'}
+      </div>
+    </div>
   );
 }
 
@@ -41,10 +62,10 @@ export default async function OgImage({ params }: { params: Promise<{ username: 
     });
   } catch (err) {
     console.error('opengraph-image[u]: user lookup failed', err);
-    return fallbackImage('Significant Hobbies');
+    return fallbackTimelineImage('Significant Hobbies');
   }
 
-  if (!user) return fallbackImage('User not found');
+  if (!user) return fallbackTimelineImage('User not found');
 
   let userTimelines: Array<{ phases: string; visibility: string }> = [];
   try {
@@ -122,33 +143,7 @@ export default async function OgImage({ params }: { params: Promise<{ username: 
       {/* Username handle */}
       <div style={{ fontSize: 28, color: '#78716C', marginBottom: 40 }}>@{username}</div>
 
-      {/* Stats */}
-      <div style={{ display: 'flex', gap: 20 }}>
-        <div
-          style={{
-            padding: '12px 28px',
-            borderRadius: 12,
-            background: '#ECFDF5',
-            color: '#059669',
-            fontSize: 22,
-            fontWeight: 700,
-          }}
-        >
-          {publicTimelines.length} timeline{publicTimelines.length !== 1 ? 's' : ''}
-        </div>
-        <div
-          style={{
-            padding: '12px 28px',
-            borderRadius: 12,
-            background: '#FEF3C7',
-            color: '#D97706',
-            fontSize: 22,
-            fontWeight: 700,
-          }}
-        >
-          {allHobbies.size} hobb{allHobbies.size !== 1 ? 'ies' : 'y'}
-        </div>
-      </div>
+      <UserProfileOgStats publicTimelines={publicTimelines} hobbyCount={allHobbies.size} />
     </div>,
     { width: 1200, height: 630 }
   );

--- a/src/hooks/use-quest-progress.ts
+++ b/src/hooks/use-quest-progress.ts
@@ -40,35 +40,58 @@ function persist(progress: QuestProgress) {
   });
 }
 
+const COUNT_BADGES: ReadonlyArray<{ threshold: number; badge: string }> = [
+  { threshold: 1, badge: 'first-steps' },
+  { threshold: 5, badge: 'curious-cat' },
+  { threshold: 10, badge: 'adventurer' },
+  { threshold: 50, badge: 'quest-master' },
+];
+
+const CATEGORY_MASTERY_BADGES: ReadonlyArray<{ category: string; badge: string }> = [
+  { category: 'sensory', badge: 'sensor' },
+  { category: 'creative', badge: 'maker' },
+  { category: 'culinary', badge: 'chefs-kiss' },
+  { category: 'social', badge: 'people-person' },
+  { category: 'exploration', badge: 'wanderer' },
+  { category: 'mindful', badge: 'zen-master' },
+];
+
+const SPECIFIC_QUEST_BADGES: ReadonlyArray<{ questId: string; badge: string }> = [
+  { questId: 'sq-03', badge: 'night-owl' }, // stargazing
+  { questId: 'sq-44', badge: 'unplugged' }, // social media detox
+];
+
+const CATEGORY_MASTERY_THRESHOLD = 3;
+const RENAISSANCE_CATEGORY_COUNT = 6;
+
 function evaluateQuestBadges(completedQuestIds: string[]): string[] {
   const earned: string[] = [];
-  const count = completedQuestIds.length;
+  const completedSet = new Set(completedQuestIds);
 
-  const completedQuests = SIDE_QUESTS.filter((q) => completedQuestIds.includes(q.id));
   const categoryCounts: Record<string, number> = {};
-  for (const q of completedQuests) {
-    categoryCounts[q.category] = (categoryCounts[q.category] ?? 0) + 1;
+  for (const q of SIDE_QUESTS) {
+    if (completedSet.has(q.id)) {
+      categoryCounts[q.category] = (categoryCounts[q.category] ?? 0) + 1;
+    }
   }
-  const categoriesWithCompletions = Object.keys(categoryCounts);
 
   // Quest progression badges
-  if (count >= 1) earned.push('first-steps');
-  if (count >= 5) earned.push('curious-cat');
-  if (count >= 10) earned.push('adventurer');
-  if (count >= 50) earned.push('quest-master');
-  if (categoriesWithCompletions.length >= 6) earned.push('renaissance-soul');
+  for (const { threshold, badge } of COUNT_BADGES) {
+    if (completedQuestIds.length >= threshold) earned.push(badge);
+  }
+  if (Object.keys(categoryCounts).length >= RENAISSANCE_CATEGORY_COUNT) {
+    earned.push('renaissance-soul');
+  }
 
   // Category mastery badges (3+ in a category)
-  if ((categoryCounts.sensory ?? 0) >= 3) earned.push('sensor');
-  if ((categoryCounts.creative ?? 0) >= 3) earned.push('maker');
-  if ((categoryCounts.culinary ?? 0) >= 3) earned.push('chefs-kiss');
-  if ((categoryCounts.social ?? 0) >= 3) earned.push('people-person');
-  if ((categoryCounts.exploration ?? 0) >= 3) earned.push('wanderer');
-  if ((categoryCounts.mindful ?? 0) >= 3) earned.push('zen-master');
+  for (const { category, badge } of CATEGORY_MASTERY_BADGES) {
+    if ((categoryCounts[category] ?? 0) >= CATEGORY_MASTERY_THRESHOLD) earned.push(badge);
+  }
 
   // Specific quest badges
-  if (completedQuestIds.includes('sq-03')) earned.push('night-owl'); // stargazing
-  if (completedQuestIds.includes('sq-44')) earned.push('unplugged'); // social media detox
+  for (const { questId, badge } of SPECIFIC_QUEST_BADGES) {
+    if (completedSet.has(questId)) earned.push(badge);
+  }
 
   return earned;
 }

--- a/src/lib/timeline-og-image.tsx
+++ b/src/lib/timeline-og-image.tsx
@@ -1,0 +1,183 @@
+import { ImageResponse } from 'next/og';
+
+import type { Phase } from './types';
+
+export const timelineOgImageSize = { width: 1200, height: 630 };
+export const timelineOgImageContentType = 'image/png';
+
+type TimelineOgArchetype = {
+  emoji: string;
+  name: string;
+};
+
+type TimelineOgRenderInput = {
+  title: string | null;
+  username: string | null;
+  phases: Phase[];
+  totalHobbies: number;
+  archetype: TimelineOgArchetype;
+};
+
+export function fallbackTimelineImage(message: string) {
+  return new ImageResponse(
+    <div
+      style={{
+        background: '#FEFDF8',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 40,
+        fontFamily: 'system-ui, sans-serif',
+        color: '#78716C',
+      }}
+    >
+      {message}
+    </div>,
+    { width: 1200, height: 630 }
+  );
+}
+
+function TimelineOgHeader({ username }: { username: string | null }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: 40,
+      }}
+    >
+      <div style={{ fontSize: 22, color: '#059669', fontWeight: 700 }}>significanthobbies.com</div>
+      {username && <div style={{ fontSize: 22, color: '#78716C' }}>@{username}</div>}
+    </div>
+  );
+}
+
+function TimelineOgPersonalityBadge({ archetype }: { archetype: TimelineOgArchetype }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 32 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '14px 28px',
+          borderRadius: 16,
+          background: 'linear-gradient(135deg, #D1FAE5 0%, #FEF3C7 100%)',
+          border: '2px solid #A7F3D0',
+        }}
+      >
+        <span style={{ fontSize: 32 }}>{archetype.emoji}</span>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <span
+            style={{
+              fontSize: 13,
+              color: '#6B7280',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: 1,
+            }}
+          >
+            Personality
+          </span>
+          <span style={{ fontSize: 24, color: '#1C1917', fontWeight: 800 }}>{archetype.name}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TimelineOgStats({ phases, totalHobbies }: { phases: Phase[]; totalHobbies: number }) {
+  return (
+    <div style={{ display: 'flex', gap: 16, marginBottom: 40 }}>
+      <div
+        style={{
+          padding: '12px 24px',
+          borderRadius: 12,
+          background: '#ECFDF5',
+          color: '#059669',
+          fontSize: 20,
+          fontWeight: 700,
+        }}
+      >
+        {phases.length} phase{phases.length !== 1 ? 's' : ''}
+      </div>
+      <div
+        style={{
+          padding: '12px 24px',
+          borderRadius: 12,
+          background: '#FEF3C7',
+          color: '#D97706',
+          fontSize: 20,
+          fontWeight: 700,
+        }}
+      >
+        {totalHobbies} hobb{totalHobbies !== 1 ? 'ies' : 'y'}
+      </div>
+    </div>
+  );
+}
+
+function TimelineOgPhaseLabels({ phases }: { phases: Phase[] }) {
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      {phases.slice(0, 5).map((p, i) => (
+        <div
+          key={p.id}
+          style={{
+            padding: '10px 20px',
+            borderRadius: 24,
+            background: `hsl(${160 - i * 25}, 60%, 90%)`,
+            color: `hsl(${160 - i * 25}, 60%, 30%)`,
+            fontSize: 20,
+            fontWeight: 600,
+          }}
+        >
+          {p.label}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function renderTimelineOgImage({
+  title,
+  username,
+  phases,
+  totalHobbies,
+  archetype,
+}: TimelineOgRenderInput) {
+  return new ImageResponse(
+    <div
+      style={{
+        background: 'linear-gradient(135deg, #FEFDF8 0%, #ECFDF5 60%, #FFF8EE 100%)',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '60px 80px',
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
+      <TimelineOgHeader username={username} />
+      <div
+        style={{
+          fontSize: 52,
+          fontWeight: 800,
+          color: '#1C1917',
+          lineHeight: 1.2,
+          marginBottom: 24,
+          maxWidth: 800,
+        }}
+      >
+        {title ?? 'Hobby Timeline'}
+      </div>
+      <TimelineOgPersonalityBadge archetype={archetype} />
+      <TimelineOgStats phases={phases} totalHobbies={totalHobbies} />
+      <TimelineOgPhaseLabels phases={phases} />
+    </div>,
+    { width: 1200, height: 630 }
+  );
+}


### PR DESCRIPTION
Closes #89

## Summary

Reduces accepted code-health debt by removing duplication and lowering cyclomatic complexity, then ratchets the baselines in `scripts/check-code-health.mjs` down to match the improved measurements. No product behavior changes.

## Changes

**Deduplication — OG image rendering**
- Extracted the shared timeline OG-image rendering (fallback image + full JSX) into a new `src/lib/timeline-og-image.tsx` module.
- The three `opengraph-image.tsx` routes (`timeline/[id]`, `u/[username]/[slug]`, `u/[username]`) now import the shared `fallbackTimelineImage` / `renderTimelineOgImage` helpers and shared `size`/`contentType` constants instead of duplicating ~175 lines.
- The shared render is split into small sub-components (`TimelineOgHeader`, `TimelineOgPersonalityBadge`, `TimelineOgStats`, `TimelineOgPhaseLabels`) so no new length violations are introduced.

**Complexity — `evaluateQuestBadges`**
- Refactored the badge-evaluation logic in `src/hooks/use-quest-progress.ts` from a chain of 13 inline conditional pushes into three data-driven lookup tables (`COUNT_BADGES`, `CATEGORY_MASTERY_BADGES`, `SPECIFIC_QUEST_BADGES`), dropping its cyclomatic complexity from 29 to single digits while preserving badge order and behavior exactly.

**Ratcheted baselines** (`scripts/check-code-health.mjs`)
- `complexity.violations`: 85 → 82
- `duplication.clones`: 52 → 50
- `duplication.duplicatedLines`: 945 → 771
- `duplication.percentage`: 1.6016 → 1.3082

`maxCcn`, `maxLength`, `maxParams`, unused, and suppressions baselines are unchanged (no improvement measured there).

## Verification

Full `pnpm quality:web` gate passes: format:check, lint, typecheck, astro check, test:coverage (487 passed), unused, complexity, duplication, cycles, dependencies, suppressions, docs:check, hygiene.