### PR TITLE
Add portfolio project strip

### DIFF
--- a/landing-astro/src/components/FleetFooter.astro
+++ b/landing-astro/src/components/FleetFooter.astro
@@ -1,38 +1,7 @@
----
-const fleet = [
-  { name: 'Foundry', url: 'https://sassmaker.com', blurb: 'SaaS factory floor' },
-  { name: 'Aliveville', url: 'https://aliveville.com', blurb: 'AI world simulator' },
-  { name: 'CodeVetter', url: 'https://codevetter.com', blurb: 'AI code review' },
-  { name: 'High Signal', url: 'https://highsignal.app', blurb: 'Daily tech/startup brief' },
-  { name: 'Karte', url: 'https://karte.cc', blurb: 'AI link-in-bio' },
-  { name: 'RolePatch', url: 'https://rolepatch.com', blurb: 'AI resume tailoring' },
-  { name: 'Materia', url: 'https://materia.io', blurb: 'Evidence-graded remedies' },
-];
----
-
-<footer class="border-t border-[#d4c74c] bg-[#f7e957] px-6 py-12 lg:px-12">
+<footer class="border-t border-[#d4c74c] bg-[#f7e957] px-6 py-8 lg:px-12">
   <div class="mx-auto max-w-5xl">
-    <p class="mb-5 text-center text-xs font-medium uppercase tracking-wider text-muted-foreground">
-      More from the fleet
-    </p>
-    <ul class="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-sm">
-      {
-        fleet.map((site) => (
-          <li>
-            <a
-              href={site.url}
-              class="text-muted-foreground no-underline transition-colors hover:text-foreground"
-              rel="noopener"
-            >
-              <span class="font-medium text-foreground/80">{site.name}</span>
-              <span class="ml-1.5 text-muted-foreground">— {site.blurb}</span>
-            </a>
-          </li>
-        ))
-      }
-    </ul>
     <nav
-      class="mt-7 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 border-t border-border pt-6 text-xs"
+      class="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs"
       aria-label="Significant Hobbies project links"
     >
       <a href="/changelog" class="text-muted-foreground no-underline hover:text-foreground">

--- a/landing-astro/src/layouts/Layout.astro
+++ b/landing-astro/src/layouts/Layout.astro
@@ -189,5 +189,11 @@ const OG_IMAGE = `${SITE_URL}/opengraph-image`;
       })();
     </script>
     <slot />
+    <script
+      is:inline
+      src="https://sassmaker.com/project-strip.js"
+      data-project="significanthobbies"
+      defer
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary\n\n- add the shared portfolio project strip to the public landing page\n- exclude the current project while linking every other maintained public project\n- preserve the existing page design and replace any older cross-project promo where present\n\n## Validation\n\n- focused project build or typecheck passed\n- shared strip syntax and responsive browser review passed\n- catalog parity verified against sass-maker/fleet-workspace#341\n\nPart of sass-maker/fleet-workspace#341