### PR TITLE
Fix Live landing asset cache key

### DIFF
--- a/worker.mjs
+++ b/worker.mjs
@@ -174,7 +174,7 @@ export default {
       // rendered as text after the cached variants crossed.
       if (env.ASSETS && url.pathname === '/') {
         const assetRequest = isLiveLanding
-          ? new Request(new URL('/live.html', request.url), request)
+          ? new Request(new URL('/live.html', request.url), { headers: request.headers })
           : request;
         const assetResp = await env.ASSETS.fetch(assetRequest);
         // The assets binding answers If-None-Match revalidations with 304.


### PR DESCRIPTION
## Summary
- construct the Live asset request without inheriting Cloudflare request metadata
- preserve request headers while ensuring `/live.html` receives its own asset cache key

## Verification
- `pnpm exec biome check worker.mjs`
- `git diff --check`

Refs #113