### PR TITLE
Fix Journal TestFlight binary name

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -30,11 +30,11 @@ Habits are focused products built from the existing private practice data.
 ## Timeline
 
 - **2026-08-21:** Created the personal-team App Store Connect record as
-  `Journal by Significant Hobbies` while preserving the installed `Journal`
-  name and bundle ID `com.significanthobbies.app`. Journal 1.0.0 (1) passed
-  native tests, UI tests, a stable Xcode 26.6 archive, and distribution-package
-  inspection before its internal-only TestFlight upload was accepted on team
-  `8F7LXHTJZR`; Apple processing remains the final availability gate.
+  `Journal by Significant Hobbies` with bundle ID `com.significanthobbies.app`.
+  Apple rejected build 1 because its shorter binary/display names were already
+  taken. Build `1.0.0 (2)` now uses the unique product name throughout, passed
+  11 core and six UI tests plus a stable Xcode 26.6 archive, and completed
+  internal-only TestFlight processing on team `8F7LXHTJZR`.
 - **2026-08-21:** Reduced the existing native target to Journal only. The app
   retains `com.significanthobbies.app` and the versioned atlas document so
   existing writing survives, while Live, History, habit check-ins, profile
@@ -173,9 +173,9 @@ Historical milestones live in
 
 ## Products
 
-- Journal native SwiftUI iPhone beta under `ios/`; build 1.0.0 (1) has been
-  accepted for internal-only TestFlight processing and the existing bundle
-  identity is preserved.
+- Journal native SwiftUI iPhone beta under `ios/`; build 1.0.0 (2) completed
+  internal-only TestFlight processing and the existing bundle identity is
+  preserved.
 - Personal-app Hub at `https://significanthobbies.com`.
 - Live landing at `https://live.significanthobbies.com`; application routes,
   discovery, public profiles, and content remain on the same Cloudflare Worker.

--- a/ios/SignificantHobbies.xcodeproj/project.pbxproj
+++ b/ios/SignificantHobbies.xcodeproj/project.pbxproj
@@ -435,7 +435,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 8F7LXHTJZR;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -497,7 +497,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 8F7LXHTJZR;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -593,7 +593,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.significanthobbies.app;
-				PRODUCT_NAME = "Significant Hobbies";
+				PRODUCT_NAME = "Journal by Significant Hobbies";
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -635,7 +635,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.significanthobbies.app;
-				PRODUCT_NAME = "Significant Hobbies";
+				PRODUCT_NAME = "Journal by Significant Hobbies";
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/Sources/SignificantHobbies/Info.plist
+++ b/ios/Sources/SignificantHobbies/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Journal</string>
+	<string>Journal by Significant Hobbies</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -13,7 +13,7 @@ settings:
     DEVELOPMENT_TEAM: 8F7LXHTJZR
     CODE_SIGN_STYLE: Automatic
     TARGETED_DEVICE_FAMILY: "1"
-    CURRENT_PROJECT_VERSION: 1
+    CURRENT_PROJECT_VERSION: 2
     MARKETING_VERSION: 1.0.0
     ENABLE_USER_SCRIPT_SANDBOXING: YES
 targets:
@@ -39,7 +39,7 @@ targets:
     info:
       path: Sources/SignificantHobbies/Info.plist
       properties:
-        CFBundleDisplayName: Journal
+        CFBundleDisplayName: Journal by Significant Hobbies
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         CFBundleURLTypes:
@@ -59,7 +59,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.significanthobbies.app
-        PRODUCT_NAME: Significant Hobbies
+        PRODUCT_NAME: Journal by Significant Hobbies
         CODE_SIGN_ENTITLEMENTS: Sources/SignificantHobbies/SignificantHobbies.entitlements
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SUPPORTS_MACCATALYST: NO

--- a/scripts/check-native-code-health.mjs
+++ b/scripts/check-native-code-health.mjs
@@ -66,7 +66,7 @@ function productionCoverage(resultBundle) {
     capture('xcrun', ['xccov', 'view', '--report', '--json', resultBundle])
   );
   const productionTargets = report.targets.filter((target) =>
-    ['Significant Hobbies.app', 'SignificantHobbiesCore.framework'].includes(target.name)
+    ['Journal by Significant Hobbies.app', 'SignificantHobbiesCore.framework'].includes(target.name)
   );
   if (productionTargets.length !== 2) {
     throw new Error('The native coverage report did not contain both production targets.');


### PR DESCRIPTION
## Summary

- use the unique `Journal by Significant Hobbies` product/display name
- increment the iOS build from 1 to 2 after Apple rejected build 1
- record Apple processing completion on personal team `8F7LXHTJZR`

## Verification

- 11 core tests passed
- 6 UI tests passed
- Release build and signed archive succeeded with Xcode 26.6
- Apple email confirmed version 1.0.0 build 2 completed processing

Closes #119