### PR TITLE
Expose the Personal Platform identity session

### DIFF
--- a/src/app/api/personal-platform/session/route.test.ts
+++ b/src/app/api/personal-platform/session/route.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  session: null as null | { user: { id: string; email: string } },
+  appleSubject: null as string | null,
+}));
+
+vi.mock('@/lib/auth', () => ({
+  auth: { api: { getSession: async () => state.session } },
+}));
+
+vi.mock('@/server/db', () => ({
+  db: {
+    query: {
+      account: {
+        findFirst: async () =>
+          state.appleSubject === null ? undefined : { accountId: state.appleSubject },
+      },
+    },
+  },
+}));
+
+import { GET } from './route';
+
+describe('Personal Platform identity session', () => {
+  beforeEach(() => {
+    state.session = null;
+    state.appleSubject = null;
+  });
+
+  it('fails closed without a Better Auth bearer session', async () => {
+    const response = await GET(
+      new Request('https://significanthobbies.com/api/personal-platform/session')
+    );
+    expect(response.status).toBe(401);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('returns the permanent user ID and linked Apple subject', async () => {
+    state.session = { user: { id: 'shared-user', email: 'owner@example.com' } };
+    state.appleSubject = 'apple-subject';
+
+    const response = await GET(
+      new Request('https://significanthobbies.com/api/personal-platform/session', {
+        headers: { Authorization: 'Bearer signed-session' },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      userId: 'shared-user',
+      email: 'owner@example.com',
+      appleSubject: 'apple-subject',
+    });
+  });
+});

--- a/src/app/api/personal-platform/session/route.ts
+++ b/src/app/api/personal-platform/session/route.ts
@@ -1,0 +1,27 @@
+import { and, eq } from 'drizzle-orm';
+
+import { account } from '@/db/schema';
+import { auth } from '@/lib/auth';
+import { db } from '@/server/db';
+
+function json(payload: unknown, status = 200): Response {
+  return Response.json(payload, { status, headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user.id) {
+    return json({ code: 'UNAUTHORIZED', message: 'Sign in to continue.' }, 401);
+  }
+
+  const appleAccount = await db.query.account.findFirst({
+    where: and(eq(account.userId, session.user.id), eq(account.providerId, 'apple')),
+    columns: { accountId: true },
+  });
+
+  return json({
+    userId: session.user.id,
+    email: session.user.email,
+    appleSubject: appleAccount?.accountId ?? null,
+  });
+}


### PR DESCRIPTION
## Summary

- add a bearer-protected identity endpoint for the shared Personal Platform
- return the permanent Better Auth user ID and linked Apple subject
- keep responses private and fail closed without a valid session

## Validation

- `pnpm exec vitest run src/app/api/personal-platform/session/route.test.ts`
- `pnpm typecheck`
- `pnpm exec biome check src/app/api/personal-platform/session/route.ts src/app/api/personal-platform/session/route.test.ts`
- `git diff --check`

Part of Significant-Hobbies/personal-platform#3