### PR TITLE
feat: sync Journal through Personal Platform

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -26,8 +26,16 @@ Habits are focused products built from the existing private practice data.
   OAuth and native Sign in with Apple, and PostHog. Native account linking is
   explicit and never inferred from matching email addresses. D1 is
   authoritative; the retired Turso database was deleted on 2026-08-02.
+- `PersonalSyncKit` adds a durable semantic Journal outbox and cursor on top of
+  the same Better Auth bearer session. The versioned local atlas remains the
+  immediate store and existing whole-atlas sync stays available during rollout.
 
 ## Timeline
+
+- **2026-08-21:** Prepared Journal 1.0.0 (3) to publish each signed-in writing
+  version into Personal Platform while retaining the existing local document,
+  account, and whole-atlas reconciliation. Pace-created entries pull into the
+  daily Journal model; focused contract tests and a generic Release build pass.
 
 - **2026-08-21:** Created the personal-team App Store Connect record as
   `Journal by Significant Hobbies` with bundle ID `com.significanthobbies.app`.
@@ -186,7 +194,8 @@ Historical milestones live in
 
 - **Journal for iPhone:** one local-first morning/evening writing surface,
   date navigation, prior-entry context, private account sync, compatible
-  export/import, accessibility, simulator tests, and preserved pre-split data.
+  export/import, accessibility, simulator tests, preserved pre-split data, and
+  signed-in semantic Personal Platform synchronization.
   Live and Habits have no UI or write actions in this target.
 - **Runtime:** Cloudflare Worker `significanthobbies` (OpenNext) + Astro Hub
   and Live overlays. Cloudflare D1 + Drizzle ORM +

--- a/ios/README.md
+++ b/ios/README.md
@@ -2,7 +2,7 @@
 
 A private native SwiftUI journal for iOS 17 and later. The app is focused on morning and evening reflection, free writing, dates, and finding earlier entries.
 
-The existing `com.significanthobbies.app` identity and local document remain unchanged so current entries survive the split. Live and Habits records stay preserved in the compatible archive but are no longer exposed or edited by the Journal interface. Account sync remains revisioned and optional; the app is fully useful offline.
+The existing `com.significanthobbies.app` identity and local document remain unchanged so current entries survive the split. Live and Habits records stay preserved in the compatible archive but are no longer exposed or edited by the Journal interface. Account sync remains revisioned and optional; the app is fully useful offline. When signed in, saved writing also enters the shared Cloudflare Personal Platform through `PersonalSyncKit` without replacing the compatible local atlas document.
 
 ## Local checks
 
@@ -22,5 +22,6 @@ The script is locked to personal team `8F7LXHTJZR`, verifies the local signature
 
 - Complete morning/evening reflection, writing, date navigation, and archive flows on physical iPhone hardware.
 - Verify the largest Dynamic Type sizes, VoiceOver chronology, Reduce Motion, and writing keyboard behavior on hardware.
-- Verify account callback, Keychain persistence, and offline reconciliation after native account sync is enabled.
+- Verify account callback, Keychain persistence, whole-atlas reconciliation,
+  and Personal Platform push/pull on physical devices.
 - Confirm screenshots, support/privacy URLs, age rating, and App Privacy answers in App Store Connect before upload.

--- a/ios/RELEASE_METADATA.md
+++ b/ios/RELEASE_METADATA.md
@@ -1,13 +1,13 @@
 # Journal iOS release draft
 
-Preparation only. No App Store Connect record has been created.
+Internal TestFlight record exists on Sarthak's personal Apple team.
 
 ## Identity
 
 - Name: Journal
 - Bundle ID: `com.significanthobbies.app`
 - Version: `1.0.0`
-- Build: `1`
+- Build: `3`
 - SKU: `significant-hobbies-ios-1`
 - Primary language: English (U.S.)
 - Category: Lifestyle
@@ -29,7 +29,7 @@ Journal gives each day one private page. Start with a short morning reflection, 
 
 Writing is always private. There is no public profile, social feed, publishing control, XP, or shame loop.
 
-Journal remains useful without an account. If account sync is enabled, it keeps a private cross-device archive with explicit conflict choices. The preserved bundle and document identities keep entries created before the product split readable.
+Journal remains useful without an account. If account sync is enabled, it keeps a private cross-device archive with explicit conflict choices and publishes structured writing to the owner's Cloudflare Personal Platform. The preserved bundle and document identities keep entries created before the product split readable.
 
 **Keywords**
 journal,reflection,private diary,morning pages,daily notes,writing,evening review

--- a/ios/SignificantHobbies.xcodeproj/project.pbxproj
+++ b/ios/SignificantHobbies.xcodeproj/project.pbxproj
@@ -12,14 +12,18 @@
 		232BE0083A654EDA0678E35F /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5D1654F75D6BD52DEA4738 /* RootView.swift */; };
 		2744CFC51415CDCE0A39B0BC /* SignificantHobbiesCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8016DC426444E2D76EF32BB4 /* SignificantHobbiesCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4ED00C45ADB96002493EF597 /* Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7B72C12049FE81DEEE108E /* Domain.swift */; };
+		69B25EAE82A093562DF00E01 /* PersonalSyncKit in Frameworks */ = {isa = PBXBuildFile; productRef = D6234645F92BDC746B6319AB /* PersonalSyncKit */; };
 		713D9934D1E2EF54F4778EF9 /* Design.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D99A5939D824B344E6704A9 /* Design.swift */; };
 		73997EF2CCBE316A8A4AB154 /* SignificantHobbiesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CADA0312E38B323127C310 /* SignificantHobbiesApp.swift */; };
 		8718C60F2A3C7A593418343B /* CloudSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70587D4024EBCBD4A2335D71 /* CloudSync.swift */; };
 		942A77EEE223A4E0945EC4BE /* SignificantHobbiesCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8016DC426444E2D76EF32BB4 /* SignificantHobbiesCore.framework */; };
 		9CB054BDE18BF67E2F120AD6 /* SignificantHobbiesCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AFFF3B28DF309BB620A727 /* SignificantHobbiesCoreTests.swift */; };
 		AD89875F157AA02A1D13EBBF /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EA8F0EE78476D9881C7347 /* AppModel.swift */; };
+		C2FD601717B6E3743C988122 /* PersonalSyncKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9A34C6845C1CC7A25E8C327F /* PersonalSyncKit */; };
 		C499F299941E14A486903109 /* SignificantHobbiesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5197DAFED5BEB3D8E1FF6B /* SignificantHobbiesUITests.swift */; };
+		C7F9594990F4F3C0BB4EB769 /* JournalPlatformRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA8E53174F333BE6F42CD41 /* JournalPlatformRecord.swift */; };
 		D145E61360B9F2043C4B98F7 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 62223B76D2F335D38753F13F /* PrivacyInfo.xcprivacy */; };
+		DFB69840DDC0716771EA0E9C /* JournalPlatformRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BB86859D853186F562517 /* JournalPlatformRecordTests.swift */; };
 		E2940F7FB5B87D63D182CB5F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E9C9ECF6FD75300C43AE4574 /* Assets.xcassets */; };
 		E3CAE2317CCCC6B79A306D9B /* SignificantHobbiesCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8016DC426444E2D76EF32BB4 /* SignificantHobbiesCore.framework */; };
 		E8D072E503C4BFBE7C6D668C /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C7DF31D7BBD34A504FB0B5 /* Persistence.swift */; };
@@ -41,6 +45,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 2AE7ACA17160B21AD09AC9A4;
 			remoteInfo = SignificantHobbiesCore;
+		};
+		A70D3A5166A872387A48A3DE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 243196152188445AFC62BD80 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6300EF748A62C09CEC28DB0C;
+			remoteInfo = SignificantHobbies;
 		};
 		F0DE799ACACC72B5E92CB51F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -84,13 +95,16 @@
 		45756EFDB3A45F83CBF63F78 /* SignificantHobbies.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SignificantHobbies.entitlements; sourceTree = "<group>"; };
 		48EFA0E8BD9B98537969A433 /* SignificantHobbies.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SignificantHobbies.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B5197DAFED5BEB3D8E1FF6B /* SignificantHobbiesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignificantHobbiesUITests.swift; sourceTree = "<group>"; };
+		552A1E923415BCECAB7858BB /* SignificantHobbiesTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SignificantHobbiesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		55CADA0312E38B323127C310 /* SignificantHobbiesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignificantHobbiesApp.swift; sourceTree = "<group>"; };
 		62223B76D2F335D38753F13F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		70587D4024EBCBD4A2335D71 /* CloudSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSync.swift; sourceTree = "<group>"; };
 		7AA77312B5602FD12AB082F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8016DC426444E2D76EF32BB4 /* SignificantHobbiesCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SignificantHobbiesCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8FA8E53174F333BE6F42CD41 /* JournalPlatformRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalPlatformRecord.swift; sourceTree = "<group>"; };
 		AD5D1654F75D6BD52DEA4738 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		AE73F47A9024224B92970695 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		CE1BB86859D853186F562517 /* JournalPlatformRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalPlatformRecordTests.swift; sourceTree = "<group>"; };
 		D0188FEAC7CFA0623B6FF0EA /* JournalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalView.swift; sourceTree = "<group>"; };
 		D18715A25D2EC787F766FD6C /* SignificantHobbiesUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SignificantHobbiesUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF7B72C12049FE81DEEE108E /* Domain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Domain.swift; sourceTree = "<group>"; };
@@ -108,11 +122,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BAC23B5565ADA006C29A7125 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				69B25EAE82A093562DF00E01 /* PersonalSyncKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E2BAEAC9ED343066308A2830 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				E3CAE2317CCCC6B79A306D9B /* SignificantHobbiesCore.framework in Frameworks */,
+				C2FD601717B6E3743C988122 /* PersonalSyncKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +148,7 @@
 				48EFA0E8BD9B98537969A433 /* SignificantHobbies.app */,
 				8016DC426444E2D76EF32BB4 /* SignificantHobbiesCore.framework */,
 				FCECA2C6051C17B3374B3FE8 /* SignificantHobbiesCoreTests.xctest */,
+				552A1E923415BCECAB7858BB /* SignificantHobbiesTests.xctest */,
 				D18715A25D2EC787F766FD6C /* SignificantHobbiesUITests.xctest */,
 			);
 			name = Products;
@@ -141,12 +165,22 @@
 			path = Sources/SignificantHobbiesCore;
 			sourceTree = "<group>";
 		};
+		5A5F9D8D04952A401B506D51 /* SignificantHobbiesTests */ = {
+			isa = PBXGroup;
+			children = (
+				CE1BB86859D853186F562517 /* JournalPlatformRecordTests.swift */,
+			);
+			name = SignificantHobbiesTests;
+			path = Tests/SignificantHobbiesTests;
+			sourceTree = "<group>";
+		};
 		6F5982B9066C4FA230E6A8EF /* SignificantHobbies */ = {
 			isa = PBXGroup;
 			children = (
 				05EA8F0EE78476D9881C7347 /* AppModel.swift */,
 				3D99A5939D824B344E6704A9 /* Design.swift */,
 				7AA77312B5602FD12AB082F1 /* Info.plist */,
+				8FA8E53174F333BE6F42CD41 /* JournalPlatformRecord.swift */,
 				D0188FEAC7CFA0623B6FF0EA /* JournalView.swift */,
 				0C2B9B72A49B3D8612FD520D /* NativeAccountClient.swift */,
 				AD5D1654F75D6BD52DEA4738 /* RootView.swift */,
@@ -165,6 +199,7 @@
 				6F5982B9066C4FA230E6A8EF /* SignificantHobbies */,
 				16066171C19086EC8DBBC7C0 /* SignificantHobbiesCore */,
 				AC133343578A80E025294E9C /* SignificantHobbiesCoreTests */,
+				5A5F9D8D04952A401B506D51 /* SignificantHobbiesTests */,
 				EFFC64DD865C5063391C5354 /* SignificantHobbiesUITests */,
 				1259EA1335448FFBE0C8D6DD /* Products */,
 			);
@@ -271,10 +306,31 @@
 			);
 			name = SignificantHobbies;
 			packageProductDependencies = (
+				9A34C6845C1CC7A25E8C327F /* PersonalSyncKit */,
 			);
 			productName = SignificantHobbies;
 			productReference = 48EFA0E8BD9B98537969A433 /* SignificantHobbies.app */;
 			productType = "com.apple.product-type.application";
+		};
+		7124EDFE4D0D6AF71FC70B88 /* SignificantHobbiesTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B30DE5B04FFF7AC4F0D5C5EB /* Build configuration list for PBXNativeTarget "SignificantHobbiesTests" */;
+			buildPhases = (
+				81ACA028E13B93BFB37BC932 /* Sources */,
+				BAC23B5565ADA006C29A7125 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3ACFC1C996E2517663D56905 /* PBXTargetDependency */,
+			);
+			name = SignificantHobbiesTests;
+			packageProductDependencies = (
+				D6234645F92BDC746B6319AB /* PersonalSyncKit */,
+			);
+			productName = SignificantHobbiesTests;
+			productReference = 552A1E923415BCECAB7858BB /* SignificantHobbiesTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -302,6 +358,10 @@
 						DevelopmentTeam = 8F7LXHTJZR;
 						ProvisioningStyle = Automatic;
 					};
+					7124EDFE4D0D6AF71FC70B88 = {
+						DevelopmentTeam = 8F7LXHTJZR;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 47CB4E5FABA5092131474791 /* Build configuration list for PBXProject "SignificantHobbies" */;
@@ -313,6 +373,9 @@
 			);
 			mainGroup = 7E59BCEAD1DD090070550D90;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				0AEE6D6566507156943208A4 /* XCRemoteSwiftPackageReference "personal-platform" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1259EA1335448FFBE0C8D6DD /* Products */;
 			projectDirPath = "";
@@ -321,6 +384,7 @@
 				2AE7ACA17160B21AD09AC9A4 /* SignificantHobbiesCore */,
 				6300EF748A62C09CEC28DB0C /* SignificantHobbies */,
 				11CBCB61DBF7B0ED161A34EC /* SignificantHobbiesCoreTests */,
+				7124EDFE4D0D6AF71FC70B88 /* SignificantHobbiesTests */,
 				5056B0BE156DCB7089BA20E0 /* SignificantHobbiesUITests */,
 			);
 		};
@@ -344,6 +408,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				C499F299941E14A486903109 /* SignificantHobbiesUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		81ACA028E13B93BFB37BC932 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DFB69840DDC0716771EA0E9C /* JournalPlatformRecordTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -371,6 +443,7 @@
 			files = (
 				AD89875F157AA02A1D13EBBF /* AppModel.swift in Sources */,
 				713D9934D1E2EF54F4778EF9 /* Design.swift in Sources */,
+				C7F9594990F4F3C0BB4EB769 /* JournalPlatformRecord.swift in Sources */,
 				E99B4FB1629093EA9C77A575 /* JournalView.swift in Sources */,
 				FCE1765D393AE0E6495557B5 /* NativeAccountClient.swift in Sources */,
 				232BE0083A654EDA0678E35F /* RootView.swift in Sources */,
@@ -382,6 +455,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3ACFC1C996E2517663D56905 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6300EF748A62C09CEC28DB0C /* SignificantHobbies */;
+			targetProxy = A70D3A5166A872387A48A3DE /* PBXContainerItemProxy */;
+		};
 		3B78242B35AF05D61B9E8747 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2AE7ACA17160B21AD09AC9A4 /* SignificantHobbiesCore */;
@@ -435,7 +513,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 8F7LXHTJZR;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -497,7 +575,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 8F7LXHTJZR;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -562,6 +640,23 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = SignificantHobbies;
+			};
+			name = Debug;
+		};
+		83ECBC2A4C9303BCFB9BDD33 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.significanthobbies.app.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Journal by Significant Hobbies.app/Journal by Significant Hobbies";
 			};
 			name = Debug;
 		};
@@ -639,6 +734,23 @@
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D78552D1FECA131F5813755D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.significanthobbies.app.tests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Journal by Significant Hobbies.app/Journal by Significant Hobbies";
 			};
 			name = Release;
 		};
@@ -720,6 +832,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		B30DE5B04FFF7AC4F0D5C5EB /* Build configuration list for PBXNativeTarget "SignificantHobbiesTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83ECBC2A4C9303BCFB9BDD33 /* Debug */,
+				D78552D1FECA131F5813755D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		F36D0CF206566B5BC94EDD22 /* Build configuration list for PBXNativeTarget "SignificantHobbiesCore" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -730,6 +851,30 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		0AEE6D6566507156943208A4 /* XCRemoteSwiftPackageReference "personal-platform" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Significant-Hobbies/personal-platform.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9A34C6845C1CC7A25E8C327F /* PersonalSyncKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0AEE6D6566507156943208A4 /* XCRemoteSwiftPackageReference "personal-platform" */;
+			productName = PersonalSyncKit;
+		};
+		D6234645F92BDC746B6319AB /* PersonalSyncKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0AEE6D6566507156943208A4 /* XCRemoteSwiftPackageReference "personal-platform" */;
+			productName = PersonalSyncKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 243196152188445AFC62BD80 /* Project object */;
 }

--- a/ios/SignificantHobbies.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/SignificantHobbies.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "8bb672a61b91690298a8cde3b06b0445f363fb19078a800e40d0a67c3077a89c",
+  "pins" : [
+    {
+      "identity" : "personal-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Significant-Hobbies/personal-platform.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "28e0664ad76ab0f9b71f671abf3b796f0f241008"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/SignificantHobbies.xcodeproj/xcshareddata/xcschemes/SignificantHobbies.xcscheme
+++ b/ios/SignificantHobbies.xcodeproj/xcshareddata/xcschemes/SignificantHobbies.xcscheme
@@ -43,6 +43,20 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7124EDFE4D0D6AF71FC70B88"
+               BuildableName = "SignificantHobbiesTests.xctest"
+               BlueprintName = "SignificantHobbiesTests"
+               ReferencedContainer = "container:SignificantHobbies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "5056B0BE156DCB7089BA20E0"
                BuildableName = "SignificantHobbiesUITests.xctest"
                BlueprintName = "SignificantHobbiesUITests"
@@ -76,6 +90,17 @@
                BlueprintIdentifier = "11CBCB61DBF7B0ED161A34EC"
                BuildableName = "SignificantHobbiesCoreTests.xctest"
                BlueprintName = "SignificantHobbiesCoreTests"
+               ReferencedContainer = "container:SignificantHobbies.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7124EDFE4D0D6AF71FC70B88"
+               BuildableName = "SignificantHobbiesTests.xctest"
+               BlueprintName = "SignificantHobbiesTests"
                ReferencedContainer = "container:SignificantHobbies.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/ios/Sources/SignificantHobbies/AppModel.swift
+++ b/ios/Sources/SignificantHobbies/AppModel.swift
@@ -1,6 +1,8 @@
 import AuthenticationServices
+import CryptoKit
 import Foundation
 import Observation
+import PersonalSyncKit
 import SignificantHobbiesCore
 
 @MainActor
@@ -22,6 +24,7 @@ final class AppModel {
     private let store: AtlasStore
     private let accountClient: SignificantHobbiesNativeAccountClient
     private let webAuthenticator: SignificantHobbiesWebAuthenticator
+    private let platform: PersonalPlatformConnection?
     private var remoteRevision: Int?
     private var syncRequested = false
     private var isSyncing = false
@@ -30,11 +33,13 @@ final class AppModel {
     init(
         store: AtlasStore = AtlasStore(),
         accountClient: SignificantHobbiesNativeAccountClient = SignificantHobbiesNativeAccountClient(),
-        webAuthenticator: SignificantHobbiesWebAuthenticator = SignificantHobbiesWebAuthenticator()
+        webAuthenticator: SignificantHobbiesWebAuthenticator = SignificantHobbiesWebAuthenticator(),
+        platform: PersonalPlatformConnection? = AppModel.makePlatformConnection()
     ) {
         self.store = store
         self.accountClient = accountClient
         self.webAuthenticator = webAuthenticator
+        self.platform = Self.isAutomatedLaunch ? nil : platform
     }
 
     func load() async {
@@ -79,6 +84,7 @@ final class AppModel {
     @discardableResult
     func saveDaily(_ entry: DailyEntry, announceSuccess: Bool = true) async -> Bool {
         guard await mutate({ $0.saveDaily(entry) }) else { return false }
+        enqueueJournal(entry)
         if announceSuccess {
             message = "Private Journal entry saved on this device."
         }
@@ -127,6 +133,7 @@ final class AppModel {
             let code = try await webAuthenticator.authenticate(at: url)
             account = try await accountClient.exchangeHandoff(code)
             try await reconcileAccountCopy()
+            await syncWithPlatform()
         } catch let error as NSError
             where error.domain == ASWebAuthenticationSessionErrorDomain && error.code == 1 {
             accountMessage = nil
@@ -147,6 +154,7 @@ final class AppModel {
                 account = try await accountClient.signInWithApple(payload)
             }
             try await reconcileAccountCopy()
+            await syncWithPlatform()
         } catch {
             accountMessage = friendlyMessage(for: error)
         }
@@ -160,6 +168,7 @@ final class AppModel {
             return
         }
         await queueSync()
+        await syncWithPlatform(announcing: true)
     }
 
     func keepDeviceCopy() async {
@@ -223,7 +232,10 @@ final class AppModel {
     private func restoreAccount() async {
         do {
             account = try await accountClient.restoreAccount()
-            if account != nil { try await reconcileAccountCopy() }
+            if account != nil {
+                try await reconcileAccountCopy()
+                await syncWithPlatform()
+            }
         } catch {
             account = nil
             document.syncState = .localOnly
@@ -298,11 +310,72 @@ final class AppModel {
         }
     }
 
+    private func enqueueJournal(_ entry: DailyEntry) {
+        guard account != nil, let platform else { return }
+        let payload = JournalPlatformRecord.encode(entry)
+        let recordId = JournalPlatformRecord.versionedRecordId(entry)
+        Task {
+            do {
+                try await platform.sync.enqueue(
+                    recordId: recordId,
+                    occurredAt: JournalPlatformRecord.iso(entry.date),
+                    record: payload
+                )
+                _ = try? await platform.sync.synchronize()
+            } catch {}
+        }
+    }
+
+    private func syncWithPlatform(announcing: Bool = false) async {
+        guard account != nil, let platform else { return }
+        do {
+            let changes = try await platform.sync.synchronize()
+            var next = document
+            for change in changes {
+                if change.operation == .delete {
+                    guard let sourceId = JournalPlatformRecord.sourceId(change) else { continue }
+                    next.dailyEntries.removeAll { $0.id == sourceId }
+                } else if let entry = JournalPlatformRecord.decode(change) {
+                    next.saveDaily(entry)
+                }
+            }
+            if next != document {
+                try await store.save(next)
+                document = next
+            }
+            if announcing { accountMessage = "Journal and Personal Platform are up to date." }
+        } catch {
+            if announcing { accountMessage = "Journal sync will retry when you are online." }
+        }
+    }
+
     private func friendlyMessage(for error: Error) -> String {
         if let native = error as? NativeAccountError {
             return native.errorDescription ?? "Journal account service is unavailable."
         }
         return "Journal could not complete that account action. Try again."
+    }
+
+    private static var isAutomatedLaunch: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+            || ProcessInfo.processInfo.arguments.contains("--fresh-demo")
+    }
+
+    private static func makePlatformConnection() -> PersonalPlatformConnection? {
+        let defaults = UserDefaults.standard
+        let key = "personal-platform-device-id"
+        let deviceId = defaults.string(forKey: key) ?? UUID().uuidString.lowercased()
+        defaults.set(deviceId, forKey: key)
+        let supportDirectory = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0].appending(path: "SignificantHobbies", directoryHint: .isDirectory)
+        return try? PersonalPlatformConnection(
+            domain: .journal,
+            keychainService: "com.significanthobbies.app.session",
+            supportDirectory: supportDirectory,
+            deviceId: deviceId
+        )
     }
 
     @discardableResult

--- a/ios/Sources/SignificantHobbies/JournalPlatformRecord.swift
+++ b/ios/Sources/SignificantHobbies/JournalPlatformRecord.swift
@@ -1,0 +1,80 @@
+import CryptoKit
+import Foundation
+import PersonalSyncKit
+import SignificantHobbiesCore
+
+enum JournalPlatformRecord {
+    static func encode(_ entry: DailyEntry) -> JSONValue {
+        .object([
+            "sourceId": .string(entry.id.uuidString.lowercased()),
+            "body": .string(entry.journalBody),
+            "occurredOn": .string(iso(entry.date)),
+            "morningReflection": .string(entry.morningReflection),
+            "eveningReflection": .string(entry.eveningReflection),
+            "newThing": .string(entry.newThing),
+        ])
+    }
+
+    static func decode(_ change: SyncChange) -> DailyEntry? {
+        guard case .object(let record) = change.record,
+            case .string(let body)? = record["body"],
+            case .string(let occurredOn)? = record["occurredOn"],
+            let date = ISO8601DateFormatter().date(from: occurredOn)
+        else { return nil }
+        return DailyEntry(
+            id: sourceId(change) ?? stableUUID(change.id),
+            date: date,
+            morningReflection: record.string("morningReflection"),
+            eveningReflection: record.string("eveningReflection"),
+            journal: body,
+            newThing: record.string("newThing")
+        )
+    }
+
+    static func sourceId(_ change: SyncChange) -> UUID? {
+        guard case .object(let record) = change.record,
+            case .string(let source)? = record["sourceId"]
+        else { return nil }
+        return UUID(uuidString: source)
+    }
+
+    static func versionedRecordId(_ entry: DailyEntry) -> String {
+        let content = [
+            entry.morningReflection,
+            entry.eveningReflection,
+            entry.journal,
+            entry.newThing,
+        ].joined(separator: "\u{1f}")
+        let digest = SHA256.hash(data: Data(content.utf8)).prefix(8)
+            .map { String(format: "%02x", $0) }.joined()
+        return "\(entry.id.uuidString.lowercased()):\(digest)"
+    }
+
+    static func iso(_ date: Date) -> String { ISO8601DateFormatter().string(from: date) }
+
+    private static func stableUUID(_ value: String) -> UUID {
+        if let uuid = UUID(uuidString: value) { return uuid }
+        let bytes = Array(SHA256.hash(data: Data(value.utf8)).prefix(16))
+        return UUID(
+            uuid: (
+                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+                bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+            ))
+    }
+}
+
+extension DailyEntry {
+    fileprivate var journalBody: String {
+        if !journal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return journal }
+        return [morningReflection, eveningReflection, newThing]
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .joined(separator: "\n\n")
+    }
+}
+
+extension Dictionary where Key == String, Value == JSONValue {
+    fileprivate func string(_ key: String) -> String {
+        guard case .string(let value)? = self[key] else { return "" }
+        return value
+    }
+}

--- a/ios/Sources/SignificantHobbies/SettingsView.swift
+++ b/ios/Sources/SignificantHobbies/SettingsView.swift
@@ -103,7 +103,7 @@ struct SettingsView: View {
                             .font(.subheadline).foregroundStyle(AtlasPalette.quietInk)
                     }
                     settingsSection("About") {
-                        LabeledContent("Version", value: "1.0.0 (1)")
+                        LabeledContent("Version", value: "1.0.0 (3)")
                         Link("Privacy", destination: URL(string: "https://journal.significanthobbies.com/privacy/")!).frame(minHeight: 44)
                         Link("Support", destination: URL(string: "https://journal.significanthobbies.com/support/")!).frame(minHeight: 44)
                     }

--- a/ios/Tests/SignificantHobbiesTests/JournalPlatformRecordTests.swift
+++ b/ios/Tests/SignificantHobbiesTests/JournalPlatformRecordTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import PersonalSyncKit
+import SignificantHobbiesCore
+import XCTest
+
+@testable import Journal_by_Significant_Hobbies
+
+final class JournalPlatformRecordTests: XCTestCase {
+    func testEntryPreservesTheJournalSections() throws {
+        let date = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-21T05:30:00Z"))
+        let id = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+        let entry = DailyEntry(
+            id: id,
+            date: date,
+            morningReflection: "Begin quietly.",
+            eveningReflection: "The walk helped.",
+            journal: "A clear day.",
+            newThing: "Tried a new route."
+        )
+
+        guard case .object(let payload) = JournalPlatformRecord.encode(entry) else {
+            return XCTFail("Expected an object record")
+        }
+        XCTAssertEqual(payload["sourceId"], .string(id.uuidString.lowercased()))
+        XCTAssertEqual(payload["body"], .string("A clear day."))
+        XCTAssertEqual(payload["occurredOn"], .string("2026-08-21T05:30:00Z"))
+        XCTAssertEqual(
+            JournalPlatformRecord.versionedRecordId(entry),
+            JournalPlatformRecord.versionedRecordId(entry)
+        )
+    }
+
+    func testRemoteEntryUsesSourceIdentityAndSections() throws {
+        let change = try decodeChange(
+            id: "server-version",
+            record: """
+                {"sourceId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","body":"A clear day.","occurredOn":"2026-08-21T05:30:00Z","morningReflection":"Begin quietly.","eveningReflection":"The walk helped.","newThing":"Tried a new route."}
+                """
+        )
+        let entry = try XCTUnwrap(JournalPlatformRecord.decode(change))
+        XCTAssertEqual(entry.id, UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        XCTAssertEqual(entry.journal, "A clear day.")
+        XCTAssertEqual(entry.morningReflection, "Begin quietly.")
+        XCTAssertEqual(entry.eveningReflection, "The walk helped.")
+        XCTAssertEqual(entry.newThing, "Tried a new route.")
+    }
+
+    func testPaceEntryWithoutSourceIdentityStillImports() throws {
+        let change = try decodeChange(
+            id: "pace-entry",
+            record: "{\"body\":\"A note from Pace.\",\"occurredOn\":\"2026-08-21T06:00:00Z\"}"
+        )
+        let first = try XCTUnwrap(JournalPlatformRecord.decode(change))
+        let second = try XCTUnwrap(JournalPlatformRecord.decode(change))
+        XCTAssertEqual(first.id, second.id)
+        XCTAssertEqual(first.journal, "A note from Pace.")
+    }
+
+    private func decodeChange(id: String, record: String) throws -> SyncChange {
+        let payload = """
+            {"cursor":1,"changeId":"change-1","domain":"journal","id":"\(id)","operation":"upsert","version":1,"occurredAt":"2026-08-21T06:00:00Z","recordedAt":"2026-08-21T06:00:01Z","originDeviceId":"pace","record":\(record)}
+            """
+        return try JSONDecoder().decode(SyncChange.self, from: Data(payload.utf8))
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -13,9 +13,13 @@ settings:
     DEVELOPMENT_TEAM: 8F7LXHTJZR
     CODE_SIGN_STYLE: Automatic
     TARGETED_DEVICE_FAMILY: "1"
-    CURRENT_PROJECT_VERSION: 2
+    CURRENT_PROJECT_VERSION: 3
     MARKETING_VERSION: 1.0.0
     ENABLE_USER_SCRIPT_SANDBOXING: YES
+packages:
+  PersonalSyncKit:
+    url: https://github.com/Significant-Hobbies/personal-platform.git
+    branch: main
 targets:
   SignificantHobbiesCore:
     type: framework
@@ -36,6 +40,7 @@ targets:
         buildPhase: resources
     dependencies:
       - target: SignificantHobbiesCore
+      - package: PersonalSyncKit
     info:
       path: Sources/SignificantHobbies/Info.plist
       properties:
@@ -73,6 +78,19 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.significanthobbies.app.core-tests
         GENERATE_INFOPLIST_FILE: YES
+  SignificantHobbiesTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources: Tests/SignificantHobbiesTests
+    dependencies:
+      - target: SignificantHobbies
+      - package: PersonalSyncKit
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.significanthobbies.app.tests
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Journal by Significant Hobbies.app/Journal by Significant Hobbies"
+        BUNDLE_LOADER: "$(TEST_HOST)"
   SignificantHobbiesUITests:
     type: bundle.ui-testing
     platform: iOS
@@ -89,10 +107,12 @@ schemes:
       targets:
         SignificantHobbies: all
         SignificantHobbiesCoreTests: [test]
+        SignificantHobbiesTests: [test]
         SignificantHobbiesUITests: [test]
     test:
       targets:
         - SignificantHobbiesCoreTests
+        - SignificantHobbiesTests
         - SignificantHobbiesUITests
       gatherCoverageData: true
     run:

--- a/src/lib/native-account.test.ts
+++ b/src/lib/native-account.test.ts
@@ -10,9 +10,14 @@ import {
 import { parseNativeStateEnvelope } from './native-state';
 
 describe('native account boundary', () => {
-  it('accepts only the exact Significant Hobbies callback', () => {
+  it('accepts only exact callbacks owned by the personal app family', () => {
     expect(isAllowedNativeCallback('significanthobbies://auth')).toBe(true);
+    expect(isAllowedNativeCallback('kith://auth')).toBe(true);
+    expect(isAllowedNativeCallback('setline://auth')).toBe(true);
+    expect(isAllowedNativeCallback('habits://auth')).toBe(true);
+    expect(isAllowedNativeCallback('anchor://auth')).toBe(true);
     expect(isAllowedNativeCallback('significanthobbies://auth.evil.example')).toBe(false);
+    expect(isAllowedNativeCallback('anchor://auth.evil.example')).toBe(false);
     expect(isAllowedNativeCallback('https://significanthobbies.com/auth')).toBe(false);
   });
 

--- a/src/lib/native-handoff.ts
+++ b/src/lib/native-handoff.ts
@@ -4,10 +4,19 @@ import { nativeAuthHandoffs } from '~/db/schema';
 import { db } from '~/server/db';
 
 export const NATIVE_AUTH_CALLBACK = 'significanthobbies://auth';
+const PERSONAL_APP_AUTH_CALLBACKS = [
+  NATIVE_AUTH_CALLBACK,
+  'kith://auth',
+  'setline://auth',
+  'habits://auth',
+  'anchor://auth',
+] as const;
 const NATIVE_HANDOFF_TTL_MS = 5 * 60 * 1000;
 
 export function isAllowedNativeCallback(value: string): boolean {
-  return value === NATIVE_AUTH_CALLBACK;
+  return PERSONAL_APP_AUTH_CALLBACKS.includes(
+    value as (typeof PERSONAL_APP_AUTH_CALLBACKS)[number]
+  );
 }
 
 export function createNativeHandoffCode(): string {


### PR DESCRIPTION
Journal remains local-first while signed-in entries now push and pull through PersonalSyncKit. The Significant Hobbies auth service also exact-allowlists the Kith, Setline, Habits, and Anchor native callback schemes so every app connects to the same Better Auth account.

Validation:
- 489 web tests and all web quality gates pass
- 14 native unit tests and 6 UI tests pass
- unsigned Release build passes
- native production coverage 66.0070%

Closes #122