### PR TITLE
Verify Apple audiences for the personal app family

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,8 @@ import { eq } from 'drizzle-orm';
 import { account, session, user, users, verification } from '~/db/schema';
 import { db } from '~/server/db';
 
+import { nativeAppleAudiences } from './native-apple';
+
 const canUseLocalAuthSecret =
   process.env.NODE_ENV !== 'production' ||
   process.env.npm_lifecycle_event === 'build' ||
@@ -42,6 +44,10 @@ const baseURL =
 const googleClientId = process.env.GOOGLE_CLIENT_ID?.trim();
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim();
 const appleBundleIdentifier = process.env.APPLE_APP_BUNDLE_IDENTIFIER?.trim();
+const appleNativeAudiences = nativeAppleAudiences(
+  appleBundleIdentifier,
+  process.env.APPLE_NATIVE_AUDIENCES
+);
 
 export const auth = betterAuth({
   secret: authSecret,
@@ -60,6 +66,7 @@ export const auth = betterAuth({
             clientId: appleBundleIdentifier,
             clientSecret: '',
             appBundleIdentifier: appleBundleIdentifier,
+            audience: appleNativeAudiences,
           },
         }
       : {}),

--- a/src/lib/native-account.test.ts
+++ b/src/lib/native-account.test.ts
@@ -7,11 +7,13 @@ import {
   hashNativeHandoffCode,
   isAllowedNativeCallback,
 } from './native-handoff';
+import { nativeAppleAudiences } from './native-apple';
 import { parseNativeStateEnvelope } from './native-state';
 
 describe('native account boundary', () => {
   it('accepts only exact callbacks owned by the personal app family', () => {
     expect(isAllowedNativeCallback('significanthobbies://auth')).toBe(true);
+    expect(isAllowedNativeCallback('calorie://auth')).toBe(true);
     expect(isAllowedNativeCallback('kith://auth')).toBe(true);
     expect(isAllowedNativeCallback('setline://auth')).toBe(true);
     expect(isAllowedNativeCallback('habits://auth')).toBe(true);
@@ -53,10 +55,28 @@ describe('native account boundary', () => {
     ]);
 
     expect(auth).toMatch(/appBundleIdentifier:\s*appleBundleIdentifier/);
+    expect(auth).toMatch(/audience:\s*appleNativeAudiences/);
     expect(auth).toMatch(/disableImplicitLinking:\s*true/);
     expect(auth).toMatch(/allowDifferentEmails:\s*true/);
     expect(client).toMatch(/\/api\/auth\/sign-in\/social/);
     expect(client).toMatch(/\/api\/auth\/link-social/);
     expect(client).toMatch(/set-auth-token/);
+  });
+
+  it('accepts only the explicit personal-app Apple audiences', () => {
+    expect(
+      nativeAppleAudiences(
+        'com.significanthobbies.app',
+        ' com.significanthobbies.future,com.significanthobbies.kith '
+      )
+    ).toEqual([
+      'com.significanthobbies.app',
+      'com.significanthobbies.calorie',
+      'com.significanthobbies.setline',
+      'com.significanthobbies.kith',
+      'com.significanthobbies.indulge',
+      'com.significanthobbies.anchor',
+      'com.significanthobbies.future',
+    ]);
   });
 });

--- a/src/lib/native-apple.ts
+++ b/src/lib/native-apple.ts
@@ -1,0 +1,23 @@
+const PERSONAL_APP_BUNDLE_IDENTIFIERS = [
+  'com.significanthobbies.app',
+  'com.significanthobbies.calorie',
+  'com.significanthobbies.setline',
+  'com.significanthobbies.kith',
+  'com.significanthobbies.indulge',
+  'com.significanthobbies.anchor',
+] as const;
+
+export function nativeAppleAudiences(
+  primaryBundleIdentifier: string | undefined,
+  configuredAudiences: string | undefined
+): string[] {
+  return [
+    primaryBundleIdentifier,
+    ...PERSONAL_APP_BUNDLE_IDENTIFIERS,
+    ...(configuredAudiences?.split(',') ?? []),
+  ]
+    .map((audience) => audience?.trim() ?? '')
+    .filter(
+      (audience, index, audiences) => audience.length > 0 && audiences.indexOf(audience) === index
+    );
+}

--- a/src/lib/native-handoff.ts
+++ b/src/lib/native-handoff.ts
@@ -6,6 +6,7 @@ import { db } from '~/server/db';
 export const NATIVE_AUTH_CALLBACK = 'significanthobbies://auth';
 const PERSONAL_APP_AUTH_CALLBACKS = [
   NATIVE_AUTH_CALLBACK,
+  'calorie://auth',
   'kith://auth',
   'setline://auth',
   'habits://auth',


### PR DESCRIPTION
Part of Significant-Hobbies/personal-platform#12

## What
- centralize the explicit native Apple audience allowlist
- cover every current personal-app bundle ID
- preserve nonce validation and explicit-only account linking

## Verification
- pnpm test
- pnpm lint
- pnpm typecheck