### PR TITLE
Align Journal with the shared native account contract

### DIFF
--- a/ios/SignificantHobbies.xcodeproj/project.pbxproj
+++ b/ios/SignificantHobbies.xcodeproj/project.pbxproj
@@ -853,8 +853,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Significant-Hobbies/personal-platform.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = revision;
+				revision = a254f77f883e0ff3a85841ea9620754875a21666;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/SignificantHobbies.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/SignificantHobbies.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Significant-Hobbies/personal-platform.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "c956eb6b44fdb972ff449e1bfe3a02e7a5f28219"
+        "revision" : "a254f77f883e0ff3a85841ea9620754875a21666"
       }
     }
   ],

--- a/ios/Sources/SignificantHobbies/SettingsView.swift
+++ b/ios/Sources/SignificantHobbies/SettingsView.swift
@@ -42,11 +42,11 @@ struct SettingsView: View {
                             }
                             .frame(maxWidth: .infinity, minHeight: 48)
                         } else if !model.isAccountConnected {
+                            appleAccountButton
                             Button { Task { await model.connectAccount() } } label: {
-                                Label("Connect Google account", systemImage: "person.crop.circle.badge.plus")
+                                Label("Continue with Google", systemImage: "person.crop.circle.badge.plus")
                             }
                             .buttonStyle(AtlasPrimaryButtonStyle())
-                            appleAccountButton
                         } else {
                             if let lastSync = model.document.lastSyncedAt {
                                 LabeledContent("Last synced") {

--- a/ios/Tests/SignificantHobbiesUITests/SignificantHobbiesUITests.swift
+++ b/ios/Tests/SignificantHobbiesUITests/SignificantHobbiesUITests.swift
@@ -77,13 +77,16 @@ final class SignificantHobbiesUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Delete Journal cloud data"].exists)
     }
 
-    func testAccountScreenOffersAppleAlongsideGoogle() {
+    func testAccountScreenOffersAppleBeforeGoogle() {
         let app = XCUIApplication()
         app.launchArguments = ["--fresh-demo"]
         app.launch()
 
         app.buttons["Profile and settings"].tap()
-        XCTAssertTrue(app.buttons["Connect Google account"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.buttons["apple-account-button"].exists)
+        let appleButton = app.buttons["apple-account-button"]
+        let googleButton = app.buttons["Continue with Google"]
+        XCTAssertTrue(appleButton.waitForExistence(timeout: 3))
+        XCTAssertTrue(googleButton.exists)
+        XCTAssertLessThan(appleButton.frame.minY, googleButton.frame.minY)
     }
 }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -19,7 +19,7 @@ settings:
 packages:
   PersonalSyncKit:
     url: https://github.com/Significant-Hobbies/personal-platform.git
-    branch: main
+    revision: a254f77f883e0ff3a85841ea9620754875a21666
 targets:
   SignificantHobbiesCore:
     type: framework


### PR DESCRIPTION
## Summary\n- pin PersonalSyncKit to the verified Personal Platform contract commit\n- present Sign in with Apple before Google in Journal\n- assert the account-screen order in UI tests\n\n## Verification\n- pnpm quality:native on Xcode 27 Beta 5\n- 11 core, 3 adapter, and 6 UI tests passed\n- unsigned Release build passed\n- native coverage ratchet passed at 80.41%\n\nTracks Significant-Hobbies/personal-platform#12.