### PR TITLE
Show Personal Platform data in the authenticated Hub

### DIFF
--- a/.fleet/design-reviews/issue-130.json
+++ b/.fleet/design-reviews/issue-130.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "fleet.design-review.v1",
+  "version": 1,
+  "project": "significanthobbies",
+  "target": "Authenticated Hub Personal Platform data inventory",
+  "mode": "preserve",
+  "register": "product",
+  "context": {
+    "product": "PRODUCT.md",
+    "design": "DESIGN.md"
+  },
+  "direction": {
+    "references": [],
+    "probes": [],
+    "selected": "existing Life Atlas daylight system with an open ledger below the product directory",
+    "approval": "not-required",
+    "before": ".fleet/design-evidence/hub-data-inventory/before/hub-1440.png"
+  },
+  "evidence": {
+    "screenshots": [
+      {
+        "width": 390,
+        "path": ".fleet/design-evidence/hub-data-inventory/after/hub-390.png"
+      },
+      {
+        "width": 768,
+        "path": ".fleet/design-evidence/hub-data-inventory/after/hub-768.png"
+      },
+      {
+        "width": 1440,
+        "path": ".fleet/design-evidence/hub-data-inventory/after/hub-1440.png"
+      }
+    ],
+    "projectCheck": {
+      "command": "pnpm check; pnpm typecheck; pnpm test; pnpm build; pnpm cf:build; git diff --check; axe at 390, 768, and 1440",
+      "status": "pass"
+    },
+    "critique": {
+      "score": 35,
+      "maximum": 40
+    },
+    "audit": {
+      "score": 18,
+      "maximum": 20
+    },
+    "unresolved": {
+      "p0": 0,
+      "p1": 0
+    },
+    "detector": {
+      "posture": "advisory",
+      "findings": [
+        "The detector reported seven advisory design-system-color notes for the existing product identity pastels; no blocking findings were found.",
+        "The inventory reuses those established product colors as small wayfinding marks and introduces no new visual language.",
+        "Manual review covered populated and unavailable states. The populated state was captured at 390, 768, and 1440 px.",
+        "Axe reported zero violations at all three required widths after removing the Hub component's duplicate main landmark.",
+        "The Hub model strips raw journal bodies and relationship notes before rendering."
+      ]
+    }
+  },
+  "ownerFeedback": {
+    "decision": "delegated",
+    "note": "The owner explicitly requested a small proof-of-work surface in the Hub that shows the data available for the signed-in user."
+  }
+}

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -32,6 +32,12 @@ Habits are focused products built from the existing private practice data.
 
 ## Timeline
 
+- **2026-08-21:** Added a private proof surface to the authenticated Hub. It
+  reads the existing Personal Platform summary contract with the current
+  Better Auth session and shows per-product record counts, freshness,
+  provenance, and privacy-safe latest-record labels. The anonymous Astro
+  landing remains unchanged, raw journal text and relationship notes are not
+  rendered, and production deployment remains manual.
 - **2026-08-21:** Journal 1.0.0 (3) completed internal-only TestFlight
   processing on personal team `8F7LXHTJZR`. It publishes each signed-in writing
   version into Personal Platform while retaining the existing local document,
@@ -202,8 +208,9 @@ Historical milestones live in
 - **Runtime:** Cloudflare Worker `significanthobbies` (OpenNext) + Astro Hub
   and Live overlays. Cloudflare D1 + Drizzle ORM +
   better-auth Google OAuth. PostHog analytics.
-- **Personal-app Hub:** seven honest linked cards, no combined database, no
-  assistant, and no write actions.
+- **Personal-app Hub:** seven honest linked cards plus an authenticated,
+  read-only Personal Platform inventory. The Hub owns no combined database,
+  assistant, or write actions.
 - **Focused web products:** Live at `/live-more`, Journal at `/journal`, Habits
   at `/habits`, and `/daily` as the compatibility doorway.
 - **Owned product history:** public editorial changelog at `/changelog`.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { PersonalAppsHub } from '~/components/personal-apps-hub';
+import { getPersonalDataInventory } from '~/server/personal-platform';
 
 export const metadata = {
   title: 'Significant Hobbies — Personal Apps',
@@ -6,6 +7,7 @@ export const metadata = {
   alternates: { canonical: 'https://significanthobbies.com' },
 };
 
-export default function HomePage() {
-  return <PersonalAppsHub />;
+export default async function HomePage() {
+  const inventory = await getPersonalDataInventory();
+  return <PersonalAppsHub inventory={inventory} />;
 }

--- a/src/components/personal-apps-hub.tsx
+++ b/src/components/personal-apps-hub.tsx
@@ -1,6 +1,10 @@
 import { ArrowUpRight } from 'lucide-react';
 import Link from 'next/link';
 
+import type { PersonalDataInventory as PersonalDataInventoryModel } from '~/lib/personal-data-inventory';
+
+import { PersonalDataInventory } from './personal-data-inventory';
+
 type Product = {
   name: string;
   mark: string;
@@ -77,9 +81,9 @@ const products: Product[] = [
   },
 ];
 
-export function PersonalAppsHub() {
+export function PersonalAppsHub({ inventory }: { inventory: PersonalDataInventoryModel | null }) {
   return (
-    <main id="main" className="min-h-[calc(100vh-4.5rem)] bg-[#fffdf4] px-4 py-12 sm:py-20">
+    <div className="min-h-[calc(100vh-4.5rem)] bg-[#fffdf4] px-4 py-12 sm:py-20">
       <div className="mx-auto max-w-6xl">
         <header className="max-w-3xl">
           <p className="text-sm font-bold text-[#7658ad]">Significant Hobbies</p>
@@ -96,7 +100,7 @@ export function PersonalAppsHub() {
             <h2 id="products-heading" className="text-3xl sm:text-4xl">
               The collection
             </h2>
-            <p className="text-sm text-[#5f584c]">Directory now. Shared summaries later.</p>
+            <p className="text-sm text-[#5f584c]">Directory plus a read-only sync check.</p>
           </div>
 
           <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -151,19 +155,22 @@ export function PersonalAppsHub() {
           </div>
         </section>
 
-        <aside className="mt-10 rounded-3xl border border-[#ded5be] bg-white p-6 sm:flex sm:items-center sm:justify-between sm:gap-8">
-          <div>
-            <p className="font-semibold">No combined database yet.</p>
-            <p className="mt-1 text-sm leading-6 text-[#5f584c]">
-              Each product still owns its interface and data. Connections will be added only after
-              the split is stable.
-            </p>
-          </div>
-          <span className="mt-4 inline-flex rounded-full bg-[#f1ecdf] px-3 py-1.5 text-xs font-bold sm:mt-0">
-            Read-only Hub
-          </span>
-        </aside>
+        {inventory ? (
+          <PersonalDataInventory inventory={inventory} />
+        ) : (
+          <aside className="mt-10 rounded-3xl border border-[#ded5be] bg-white p-6 sm:flex sm:items-center sm:justify-between sm:gap-8">
+            <div>
+              <p className="font-semibold">Each product owns its data.</p>
+              <p className="mt-1 text-sm leading-6 text-[#5f584c]">
+                Sign in to confirm what has synchronized through Personal Platform.
+              </p>
+            </div>
+            <span className="mt-4 inline-flex rounded-full bg-[#f1ecdf] px-3 py-1.5 text-xs font-bold sm:mt-0">
+              Read-only Hub
+            </span>
+          </aside>
+        )}
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/components/personal-data-inventory.test.tsx
+++ b/src/components/personal-data-inventory.test.tsx
@@ -1,0 +1,44 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildPersonalDataInventory,
+  unavailablePersonalDataInventory,
+} from '~/lib/personal-data-inventory';
+
+import { PersonalDataInventory } from './personal-data-inventory';
+
+describe('PersonalDataInventory', () => {
+  it('renders connected counts and provenance without raw payloads', () => {
+    const inventory = buildPersonalDataInventory({
+      generatedAt: '2026-08-21T10:00:00.000Z',
+      source: 'personal-platform',
+      summaries: [
+        {
+          domain: 'journal',
+          activeCount: 2,
+          lastUpdatedAt: '2026-08-21T09:00:00.000Z',
+          latest: { occurredOn: '2026-08-21', body: 'private journal body' },
+          source: 'personal-platform',
+        },
+      ],
+    });
+
+    const html = renderToString(<PersonalDataInventory inventory={inventory} />);
+
+    expect(html).toContain('Platform read confirmed');
+    expect(html).toContain('2 records');
+    expect(html).toContain('Personal Platform D1');
+    expect(html).not.toContain('private journal body');
+  });
+
+  it('renders an honest non-empty failure state', () => {
+    const html = renderToString(
+      <PersonalDataInventory inventory={unavailablePersonalDataInventory()} />
+    );
+
+    expect(html).toContain('Platform read unavailable');
+    expect(html).toContain('The directory is still available.');
+    expect(html).not.toContain('0 records');
+  });
+});

--- a/src/components/personal-data-inventory.tsx
+++ b/src/components/personal-data-inventory.tsx
@@ -1,0 +1,148 @@
+import { CircleAlert, Cloud, Database } from 'lucide-react';
+
+import type {
+  PersonalDataDomain,
+  PersonalDataInventory as PersonalDataInventoryModel,
+} from '~/lib/personal-data-inventory';
+
+const domainColors: Record<PersonalDataDomain, string> = {
+  live: '#fff09a',
+  journal: '#eadcf6',
+  habits: '#dceeff',
+  calorie: '#e4efd9',
+  setline: '#f5e2d2',
+  kith: '#f6e1d4',
+  anchor: '#dce8f0',
+};
+
+export function PersonalDataInventory({ inventory }: { inventory: PersonalDataInventoryModel }) {
+  const connected = inventory.status === 'connected';
+
+  return (
+    <section
+      aria-labelledby="data-inventory-heading"
+      className="mt-16 border-t border-[#ded5be] pt-12"
+    >
+      <div className="grid gap-6 lg:grid-cols-[1fr_auto] lg:items-end">
+        <div className="max-w-3xl">
+          <p className="flex items-center gap-2 text-sm font-bold text-[#7658ad]">
+            <Database className="size-4" aria-hidden="true" />
+            Connected data
+          </p>
+          <h2 id="data-inventory-heading" className="mt-3 text-3xl sm:text-5xl">
+            What Cloudflare has for you.
+          </h2>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-[#625b50]">
+            A read-only inventory from Personal Platform. The Hub keeps no second copy and hides
+            journal text and private notes.
+          </p>
+        </div>
+        <p
+          className={`inline-flex w-fit items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-bold ${
+            connected
+              ? 'border-[#a9c69a] bg-[#edf6e9] text-[#31512a]'
+              : 'border-[#dfbd91] bg-[#fff4df] text-[#6a461a]'
+          }`}
+        >
+          {connected ? (
+            <Cloud className="size-3.5" aria-hidden="true" />
+          ) : (
+            <CircleAlert className="size-3.5" aria-hidden="true" />
+          )}
+          {connected ? 'Platform read confirmed' : 'Platform read unavailable'}
+        </p>
+      </div>
+
+      {connected ? (
+        <div className="mt-8 overflow-hidden rounded-[1.75rem] border border-[#ded5be] bg-white/75 shadow-[0_14px_40px_rgba(66,55,22,0.05)]">
+          <ul className="divide-y divide-[#e8e1d0]">
+            {inventory.domains.map((item) => (
+              <li
+                key={item.domain}
+                className="grid gap-5 px-5 py-5 sm:px-7 md:grid-cols-[minmax(10rem,0.8fr)_minmax(7rem,0.5fr)_minmax(14rem,1.3fr)] md:items-center lg:grid-cols-[minmax(10rem,0.8fr)_minmax(8rem,0.55fr)_minmax(15rem,1.4fr)_minmax(12rem,0.9fr)]"
+              >
+                <div className="flex items-center gap-3">
+                  <span
+                    aria-hidden="true"
+                    className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-black/10 font-serif text-base font-bold"
+                    style={{ backgroundColor: domainColors[item.domain] }}
+                  >
+                    {item.name.at(0)}
+                  </span>
+                  <div>
+                    <h3 className="font-serif text-xl font-semibold">{item.name}</h3>
+                    <p className="text-xs text-[#71695d]">{sourceLabel(item.source)}</p>
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-[0.12em] text-[#766e61]">
+                    {item.countScope}
+                  </p>
+                  <p className="mt-1 text-xl font-semibold tabular-nums">{countLabel(item)}</p>
+                </div>
+
+                <div>
+                  <p className="text-xs font-bold uppercase tracking-[0.12em] text-[#766e61]">
+                    Latest safe preview
+                  </p>
+                  <p className="mt-1 leading-6 text-[#37332c]">
+                    {item.status === 'unavailable'
+                      ? 'Connector unavailable'
+                      : (item.latestLabel ?? 'No synchronized record yet')}
+                  </p>
+                </div>
+
+                <div className="md:col-start-3 md:row-start-2 lg:col-start-auto lg:row-start-auto lg:text-right">
+                  <p className="text-xs font-bold uppercase tracking-[0.12em] text-[#766e61]">
+                    Last updated
+                  </p>
+                  <p className="mt-1 text-sm text-[#514c41]">
+                    {formatTimestamp(item.lastUpdatedAt)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div className="flex flex-col gap-1 border-t border-[#ded5be] bg-[#faf7ed] px-5 py-4 text-xs text-[#675f53] sm:flex-row sm:items-center sm:justify-between sm:px-7">
+            <span>
+              Cloudflare is the shared signed-in store; each app remains its own interface.
+            </span>
+            <span className="tabular-nums">Snapshot {formatTimestamp(inventory.generatedAt)}</span>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-8 rounded-[1.75rem] border border-[#dfbd91] bg-[#fff8ea] p-6 sm:p-8">
+          <p className="font-serif text-2xl font-semibold">The directory is still available.</p>
+          <p className="mt-2 max-w-2xl leading-7 text-[#625b50]">
+            Personal Platform could not confirm the Cloudflare snapshot just now. No missing data is
+            being inferred; try the Hub again after the apps have synchronized.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function countLabel(item: PersonalDataInventoryModel['domains'][number]): string {
+  if (item.count === null) return 'Unavailable';
+  if (item.countScope === 'today') return `${item.count} ${item.count === 1 ? 'entry' : 'entries'}`;
+  return `${item.count} ${item.count === 1 ? 'record' : 'records'}`;
+}
+
+function sourceLabel(source: string | null): string {
+  if (source === 'personal-platform') return 'Personal Platform D1';
+  if (source === 'calorie-service') return 'Calorie D1 connector';
+  return source ?? 'Connector unavailable';
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'Not yet';
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return 'Unknown';
+  return new Intl.DateTimeFormat('en-IN', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'Asia/Kolkata',
+  }).format(date);
+}

--- a/src/lib/personal-data-inventory.test.ts
+++ b/src/lib/personal-data-inventory.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPersonalDataInventory } from './personal-data-inventory';
+
+describe('buildPersonalDataInventory', () => {
+  it('maps the Personal Platform snapshot in a stable product order', () => {
+    const inventory = buildPersonalDataInventory({
+      generatedAt: '2026-08-21T10:00:00.000Z',
+      source: 'personal-platform',
+      summaries: [
+        {
+          domain: 'journal',
+          activeCount: 2,
+          lastUpdatedAt: '2026-08-21T09:00:00.000Z',
+          latest: { occurredOn: '2026-08-21', body: 'private writing' },
+          source: 'personal-platform',
+        },
+        {
+          domain: 'live',
+          activeCount: 1,
+          lastUpdatedAt: '2026-08-20T09:00:00.000Z',
+          latest: { title: 'See the northern lights', notes: 'private plans' },
+          source: 'personal-platform',
+        },
+        {
+          domain: 'calorie',
+          status: 'connected',
+          source: 'calorie-service',
+          summary: {
+            entryCount: 3,
+            lastUpdatedAt: '2026-08-21T08:00:00.000Z',
+            totals: { calories: 1240, proteinG: 86.5 },
+          },
+        },
+      ],
+    });
+
+    expect(inventory.status).toBe('connected');
+    expect(inventory.domains.map((domain) => domain.domain)).toEqual([
+      'live',
+      'journal',
+      'habits',
+      'calorie',
+      'setline',
+      'kith',
+      'anchor',
+    ]);
+    expect(inventory.domains[0]).toMatchObject({
+      count: 1,
+      latestLabel: 'See the northern lights',
+      status: 'connected',
+    });
+    expect(inventory.domains[1]).toMatchObject({
+      count: 2,
+      latestLabel: 'Entry from 2026-08-21',
+    });
+    expect(inventory.domains[3]).toMatchObject({
+      count: 3,
+      countScope: 'today',
+      latestLabel: '1,240 kcal · 86.5 g protein',
+    });
+    expect(inventory.domains[2].status).toBe('unavailable');
+  });
+
+  it('does not carry journal bodies or relationship notes into the Hub model', () => {
+    const inventory = buildPersonalDataInventory({
+      summaries: [
+        {
+          domain: 'journal',
+          activeCount: 1,
+          latest: { occurredOn: '2026-08-21', body: 'do not render this journal body' },
+          source: 'personal-platform',
+        },
+        {
+          domain: 'kith',
+          activeCount: 1,
+          latest: {
+            personName: 'Rahul',
+            kind: 'conversation',
+            note: 'do not render this relationship note',
+          },
+          source: 'personal-platform',
+        },
+      ],
+    });
+    const renderedModel = JSON.stringify(inventory);
+
+    expect(renderedModel).not.toContain('do not render this journal body');
+    expect(renderedModel).not.toContain('do not render this relationship note');
+    expect(renderedModel).toContain('Entry from 2026-08-21');
+    expect(renderedModel).toContain('Interaction with Rahul');
+  });
+
+  it('fails closed on a malformed response', () => {
+    const inventory = buildPersonalDataInventory({ source: 'personal-platform' });
+
+    expect(inventory.status).toBe('unavailable');
+    expect(inventory.domains).toHaveLength(7);
+    expect(inventory.domains.every((domain) => domain.status === 'unavailable')).toBe(true);
+  });
+});

--- a/src/lib/personal-data-inventory.ts
+++ b/src/lib/personal-data-inventory.ts
@@ -1,4 +1,4 @@
-export const personalDataDomains = [
+const personalDataDomains = [
   'live',
   'journal',
   'habits',
@@ -10,7 +10,7 @@ export const personalDataDomains = [
 
 export type PersonalDataDomain = (typeof personalDataDomains)[number];
 
-export type PersonalDataDomainInventory = {
+type PersonalDataDomainInventory = {
   domain: PersonalDataDomain;
   name: string;
   count: number | null;

--- a/src/lib/personal-data-inventory.ts
+++ b/src/lib/personal-data-inventory.ts
@@ -1,0 +1,200 @@
+export const personalDataDomains = [
+  'live',
+  'journal',
+  'habits',
+  'calorie',
+  'setline',
+  'kith',
+  'anchor',
+] as const;
+
+export type PersonalDataDomain = (typeof personalDataDomains)[number];
+
+export type PersonalDataDomainInventory = {
+  domain: PersonalDataDomain;
+  name: string;
+  count: number | null;
+  countScope: 'all records' | 'today';
+  lastUpdatedAt: string | null;
+  latestLabel: string | null;
+  source: string | null;
+  status: 'connected' | 'empty' | 'unavailable';
+};
+
+export type PersonalDataInventory = {
+  generatedAt: string | null;
+  source: string | null;
+  status: 'connected' | 'unavailable';
+  domains: PersonalDataDomainInventory[];
+};
+
+const domainNames: Record<PersonalDataDomain, string> = {
+  live: 'Live',
+  journal: 'Journal',
+  habits: 'Habits',
+  calorie: 'Calorie',
+  setline: 'Setline',
+  kith: 'Kith',
+  anchor: 'Anchor',
+};
+
+export function buildPersonalDataInventory(value: unknown): PersonalDataInventory {
+  const payload = record(value);
+  const summaries = Array.isArray(payload?.summaries) ? payload.summaries : null;
+  if (!payload || !summaries) return unavailablePersonalDataInventory();
+
+  return {
+    generatedAt: text(payload.generatedAt),
+    source: text(payload.source),
+    status: 'connected',
+    domains: personalDataDomains.map((domain) => {
+      const summary = summaries.map(record).find((item) => item?.domain === domain) ?? null;
+      return domain === 'calorie'
+        ? calorieInventory(summary)
+        : platformDomainInventory(domain, summary);
+    }),
+  };
+}
+
+export function unavailablePersonalDataInventory(): PersonalDataInventory {
+  return {
+    generatedAt: null,
+    source: null,
+    status: 'unavailable',
+    domains: personalDataDomains.map((domain) => ({
+      domain,
+      name: domainNames[domain],
+      count: null,
+      countScope: domain === 'calorie' ? 'today' : 'all records',
+      lastUpdatedAt: null,
+      latestLabel: null,
+      source: null,
+      status: 'unavailable',
+    })),
+  };
+}
+
+function platformDomainInventory(
+  domain: Exclude<PersonalDataDomain, 'calorie'>,
+  summary: Record<string, unknown> | null
+): PersonalDataDomainInventory {
+  const count = number(summary?.activeCount);
+  const latest = record(summary?.latest);
+  if (count === null) return unavailableDomain(domain, 'all records', text(summary?.source));
+
+  return {
+    domain,
+    name: domainNames[domain],
+    count,
+    countScope: 'all records',
+    lastUpdatedAt: text(summary?.lastUpdatedAt),
+    latestLabel: latestLabel(domain, latest),
+    source: text(summary?.source),
+    status: count === 0 ? 'empty' : 'connected',
+  };
+}
+
+function calorieInventory(summary: Record<string, unknown> | null): PersonalDataDomainInventory {
+  const source = text(summary?.source);
+  const details = record(summary?.summary);
+  const count = number(details?.entryCount);
+  if (summary?.status !== 'connected' || count === null) {
+    return unavailableDomain('calorie', 'today', source);
+  }
+
+  const totals = record(details?.totals);
+  const calories = number(totals?.calories);
+  const protein = number(totals?.proteinG);
+  const nutrients = [
+    calories === null ? null : `${formatNumber(calories)} kcal`,
+    protein === null ? null : `${formatNumber(protein)} g protein`,
+  ].filter((item): item is string => item !== null);
+
+  return {
+    domain: 'calorie',
+    name: domainNames.calorie,
+    count,
+    countScope: 'today',
+    lastUpdatedAt: text(details?.lastUpdatedAt),
+    latestLabel: nutrients.length > 0 ? nutrients.join(' · ') : null,
+    source,
+    status: count === 0 ? 'empty' : 'connected',
+  };
+}
+
+function latestLabel(
+  domain: Exclude<PersonalDataDomain, 'calorie'>,
+  latest: Record<string, unknown> | null
+): string | null {
+  if (!latest) return null;
+  switch (domain) {
+    case 'live':
+      return text(latest.title);
+    case 'journal': {
+      const occurredOn = text(latest.occurredOn);
+      return occurredOn ? `Entry from ${occurredOn}` : 'Journal entry';
+    }
+    case 'habits': {
+      const name = text(latest.name);
+      const status = text(latest.status);
+      return [name, status].filter(Boolean).join(' · ') || null;
+    }
+    case 'setline': {
+      const title = text(latest.title);
+      const minutes = number(latest.minutes);
+      return (
+        [title, minutes === null ? null : `${formatNumber(minutes)} min`]
+          .filter(Boolean)
+          .join(' · ') || null
+      );
+    }
+    case 'kith': {
+      const personName = text(latest.personName);
+      return personName ? `Interaction with ${personName}` : 'Interaction recorded';
+    }
+    case 'anchor': {
+      const title = text(latest.title);
+      const durationSeconds = number(latest.durationSeconds);
+      const duration =
+        durationSeconds === null ? null : `${formatNumber(Math.round(durationSeconds / 60))} min`;
+      return [title, duration].filter(Boolean).join(' · ') || null;
+    }
+    default:
+      return null;
+  }
+}
+
+function unavailableDomain(
+  domain: PersonalDataDomain,
+  countScope: PersonalDataDomainInventory['countScope'],
+  source: string | null
+): PersonalDataDomainInventory {
+  return {
+    domain,
+    name: domainNames[domain],
+    count: null,
+    countScope,
+    lastUpdatedAt: null,
+    latestLabel: null,
+    source,
+    status: 'unavailable',
+  };
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function number(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en', { maximumFractionDigits: 1 }).format(value);
+}

--- a/src/server/personal-platform.ts
+++ b/src/server/personal-platform.ts
@@ -1,0 +1,35 @@
+import { headers } from 'next/headers';
+
+import { auth } from '~/lib/auth';
+import {
+  buildPersonalDataInventory,
+  type PersonalDataInventory,
+  unavailablePersonalDataInventory,
+} from '~/lib/personal-data-inventory';
+
+const DEFAULT_PERSONAL_PLATFORM_URL = 'https://personal-platform.sarthakagrawal927.workers.dev';
+
+export async function getPersonalDataInventory(): Promise<PersonalDataInventory | null> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.session.token) return null;
+
+  try {
+    const response = await fetch(personalPlatformTodayURL(), {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(4_000),
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${session.session.token}`,
+      },
+    });
+    if (!response.ok) return unavailablePersonalDataInventory();
+    return buildPersonalDataInventory(await response.json());
+  } catch {
+    return unavailablePersonalDataInventory();
+  }
+}
+
+function personalPlatformTodayURL(): string {
+  const baseURL = process.env.PERSONAL_PLATFORM_URL?.trim() || DEFAULT_PERSONAL_PLATFORM_URL;
+  return new URL('/v1/life/today', baseURL).toString();
+}


### PR DESCRIPTION
## Summary
- read the existing Personal Platform `life/today` snapshot with the signed-in Better Auth session
- show counts, freshness, provenance, and privacy-safe latest-record labels for all seven domains
- keep the anonymous landing untouched and fail back to an honest unavailable state
- remove the duplicate main landmark exposed by the new responsive accessibility pass

## Verification
- `pnpm check`
- `pnpm typecheck`
- `pnpm test` — 57 files, 495 tests
- `pnpm build`
- `pnpm cf:build`
- Axe at 390, 768, and 1440 px — 0 violations
- preserve-mode design review passed at 35/40 critique and 18/20 audit
- live Personal Platform health returned 200; protected `life/today` returned 401 without a session

No deployment or migration is included.

Closes #130