### PR TITLE
Connect Live and Journal to the personal data plane

### DIFF
--- a/ios/SignificantHobbies.xcodeproj/project.pbxproj
+++ b/ios/SignificantHobbies.xcodeproj/project.pbxproj
@@ -854,7 +854,7 @@
 			repositoryURL = "https://github.com/Significant-Hobbies/personal-platform.git";
 			requirement = {
 				kind = revision;
-				revision = a254f77f883e0ff3a85841ea9620754875a21666;
+				revision = 55176cac008d3857ef815d9bc5c8e74b68e7c3f3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/SignificantHobbies.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/SignificantHobbies.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Significant-Hobbies/personal-platform.git",
       "state" : {
-        "revision" : "a254f77f883e0ff3a85841ea9620754875a21666"
+        "revision" : "55176cac008d3857ef815d9bc5c8e74b68e7c3f3"
       }
     }
   ],

--- a/ios/Sources/SignificantHobbies/AppModel.swift
+++ b/ios/Sources/SignificantHobbies/AppModel.swift
@@ -214,6 +214,13 @@ final class AppModel {
         document.syncState = .pending
         try? await store.save(document)
         do {
+            for entry in document.dailyEntries {
+                try await platform.sync.enqueue(
+                    recordId: JournalPlatformRecord.recordId(entry),
+                    occurredAt: JournalPlatformRecord.iso(entry.date),
+                    record: JournalPlatformRecord.encode(entry)
+                )
+            }
             let changes = try await platform.sync.synchronize()
             var next = document
             for change in changes {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -19,7 +19,7 @@ settings:
 packages:
   PersonalSyncKit:
     url: https://github.com/Significant-Hobbies/personal-platform.git
-    revision: a254f77f883e0ff3a85841ea9620754875a21666
+    revision: 55176cac008d3857ef815d9bc5c8e74b68e7c3f3
 targets:
   SignificantHobbiesCore:
     type: framework

--- a/src/app/api/personal-platform/live/records/route.ts
+++ b/src/app/api/personal-platform/live/records/route.ts
@@ -1,0 +1,12 @@
+import { json, liveReadError, personalPlatformUser } from '../route-helpers';
+import { parseLiveReadQuery, readLiveRecords } from '@/server/personal-platform-live';
+
+export async function GET(request: Request): Promise<Response> {
+  const user = await personalPlatformUser(request);
+  if (user instanceof Response) return user;
+  try {
+    return json(await readLiveRecords(user, parseLiveReadQuery(new URL(request.url))));
+  } catch (error) {
+    return liveReadError(error);
+  }
+}

--- a/src/app/api/personal-platform/live/route-helpers.ts
+++ b/src/app/api/personal-platform/live/route-helpers.ts
@@ -1,0 +1,25 @@
+import { auth } from '@/lib/auth';
+import { LiveReadError } from '@/server/personal-platform-live';
+
+export async function personalPlatformUser(request: Request): Promise<string | Response> {
+  const forwardedUserId = request.headers.get('X-Personal-User-Id');
+  if (new URL(request.url).hostname === 'personal-auth.internal' && forwardedUserId) {
+    return forwardedUserId;
+  }
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user.id || !forwardedUserId || forwardedUserId !== session.user.id) {
+    return json({ code: 'UNAUTHORIZED', message: 'Sign in to continue.' }, 401);
+  }
+  return session.user.id;
+}
+
+export function liveReadError(error: unknown): Response {
+  if (error instanceof LiveReadError) {
+    return json({ code: error.code, message: error.message }, 400);
+  }
+  throw error;
+}
+
+export function json(payload: unknown, status = 200): Response {
+  return Response.json(payload, { status, headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/app/api/personal-platform/live/summary/route.ts
+++ b/src/app/api/personal-platform/live/summary/route.ts
@@ -1,0 +1,8 @@
+import { personalPlatformUser, json } from '../route-helpers';
+import { readLiveSummary } from '@/server/personal-platform-live';
+
+export async function GET(request: Request): Promise<Response> {
+  const user = await personalPlatformUser(request);
+  if (user instanceof Response) return user;
+  return json(await readLiveSummary(user));
+}

--- a/src/components/personal-data-inventory.test.tsx
+++ b/src/components/personal-data-inventory.test.tsx
@@ -10,19 +10,32 @@ import { PersonalDataInventory } from './personal-data-inventory';
 
 describe('PersonalDataInventory', () => {
   it('renders connected counts and provenance without raw payloads', () => {
-    const inventory = buildPersonalDataInventory({
-      generatedAt: '2026-08-21T10:00:00.000Z',
-      source: 'personal-platform',
-      summaries: [
-        {
-          domain: 'journal',
-          activeCount: 2,
-          lastUpdatedAt: '2026-08-21T09:00:00.000Z',
-          latest: { occurredOn: '2026-08-21', body: 'private journal body' },
-          source: 'personal-platform',
-        },
-      ],
-    });
+    const inventory = buildPersonalDataInventory(
+      {
+        generatedAt: '2026-08-21T10:00:00.000Z',
+        source: 'personal-platform',
+        summaries: [
+          {
+            domain: 'journal',
+            activeCount: 2,
+            lastUpdatedAt: '2026-08-21T09:00:00.000Z',
+            latest: { occurredOn: '2026-08-21', body: 'private journal body' },
+            source: 'personal-platform',
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: 'event-1',
+            domain: 'journal',
+            eventType: 'journal.updated',
+            occurredAt: '2026-08-21T09:00:00.000Z',
+            summary: 'private activity summary',
+          },
+        ],
+      }
+    );
 
     const html = renderToString(<PersonalDataInventory inventory={inventory} />);
 
@@ -30,6 +43,10 @@ describe('PersonalDataInventory', () => {
     expect(html).toContain('2 records');
     expect(html).toContain('Personal Platform D1');
     expect(html).not.toContain('private journal body');
+    expect(html).toContain('Recent sync activity');
+    expect(html).toContain('Journal</span> record');
+    expect(html).toContain('updated');
+    expect(html).not.toContain('private activity summary');
   });
 
   it('renders an honest non-empty failure state', () => {

--- a/src/components/personal-data-inventory.tsx
+++ b/src/components/personal-data-inventory.tsx
@@ -110,6 +110,37 @@ export function PersonalDataInventory({ inventory }: { inventory: PersonalDataIn
             </span>
             <span className="tabular-nums">Snapshot {formatTimestamp(inventory.generatedAt)}</span>
           </div>
+
+          <div className="border-t border-[#ded5be] px-5 py-6 sm:px-7">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <h3 className="font-serif text-2xl font-semibold">Recent sync activity</h3>
+              <p className="text-xs text-[#675f53]">Metadata only; private writing stays hidden.</p>
+            </div>
+            {inventory.recentActivity.length > 0 ? (
+              <ol className="mt-4 grid gap-x-8 gap-y-3 md:grid-cols-2">
+                {inventory.recentActivity.map((item) => (
+                  <li
+                    key={item.id}
+                    className="flex min-w-0 items-center justify-between gap-4 border-t border-[#ebe5d7] pt-3"
+                  >
+                    <p className="min-w-0 truncate text-sm text-[#37332c]">
+                      <span className="font-semibold">{item.name}</span> record {item.action}
+                    </p>
+                    <time
+                      className="shrink-0 text-xs tabular-nums text-[#675f53]"
+                      dateTime={item.occurredAt}
+                    >
+                      {formatTimestamp(item.occurredAt)}
+                    </time>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="mt-3 text-sm leading-6 text-[#625b50]">
+                No native-app sync activity has reached Personal Platform yet.
+              </p>
+            )}
+          </div>
         </div>
       ) : (
         <div className="mt-8 rounded-[1.75rem] border border-[#dfbd91] bg-[#fff8ea] p-6 sm:p-8">

--- a/src/lib/personal-data-inventory.test.ts
+++ b/src/lib/personal-data-inventory.test.ts
@@ -4,36 +4,49 @@ import { buildPersonalDataInventory } from './personal-data-inventory';
 
 describe('buildPersonalDataInventory', () => {
   it('maps the Personal Platform snapshot in a stable product order', () => {
-    const inventory = buildPersonalDataInventory({
-      generatedAt: '2026-08-21T10:00:00.000Z',
-      source: 'personal-platform',
-      summaries: [
-        {
-          domain: 'journal',
-          activeCount: 2,
-          lastUpdatedAt: '2026-08-21T09:00:00.000Z',
-          latest: { occurredOn: '2026-08-21', body: 'private writing' },
-          source: 'personal-platform',
-        },
-        {
-          domain: 'live',
-          activeCount: 1,
-          lastUpdatedAt: '2026-08-20T09:00:00.000Z',
-          latest: { title: 'See the northern lights', notes: 'private plans' },
-          source: 'personal-platform',
-        },
-        {
-          domain: 'calorie',
-          status: 'connected',
-          source: 'calorie-service',
-          summary: {
-            entryCount: 3,
-            lastUpdatedAt: '2026-08-21T08:00:00.000Z',
-            totals: { calories: 1240, proteinG: 86.5 },
+    const inventory = buildPersonalDataInventory(
+      {
+        generatedAt: '2026-08-21T10:00:00.000Z',
+        source: 'personal-platform',
+        summaries: [
+          {
+            domain: 'journal',
+            activeCount: 2,
+            lastUpdatedAt: '2026-08-21T09:00:00.000Z',
+            latest: { occurredOn: '2026-08-21', body: 'private writing' },
+            source: 'personal-platform',
           },
-        },
-      ],
-    });
+          {
+            domain: 'live',
+            activeCount: 1,
+            lastUpdatedAt: '2026-08-20T09:00:00.000Z',
+            latest: { title: 'See the northern lights', notes: 'private plans' },
+            source: 'personal-platform',
+          },
+          {
+            domain: 'calorie',
+            status: 'connected',
+            source: 'calorie-service',
+            summary: {
+              entryCount: 3,
+              lastUpdatedAt: '2026-08-21T08:00:00.000Z',
+              totals: { calories: 1240, proteinG: 86.5 },
+            },
+          },
+        ],
+      },
+      {
+        items: [
+          {
+            id: 'event-1',
+            domain: 'journal',
+            eventType: 'journal.updated',
+            occurredAt: '2026-08-21T09:00:00.000Z',
+            summary: 'private content must not pass through',
+          },
+        ],
+      }
+    );
 
     expect(inventory.status).toBe('connected');
     expect(inventory.domains.map((domain) => domain.domain)).toEqual([
@@ -60,6 +73,16 @@ describe('buildPersonalDataInventory', () => {
       latestLabel: '1,240 kcal · 86.5 g protein',
     });
     expect(inventory.domains[2].status).toBe('unavailable');
+    expect(inventory.recentActivity).toEqual([
+      {
+        id: 'event-1',
+        domain: 'journal',
+        name: 'Journal',
+        occurredAt: '2026-08-21T09:00:00.000Z',
+        action: 'updated',
+      },
+    ]);
+    expect(JSON.stringify(inventory)).not.toContain('private content');
   });
 
   it('does not carry journal bodies or relationship notes into the Hub model', () => {

--- a/src/lib/personal-data-inventory.ts
+++ b/src/lib/personal-data-inventory.ts
@@ -26,6 +26,15 @@ export type PersonalDataInventory = {
   source: string | null;
   status: 'connected' | 'unavailable';
   domains: PersonalDataDomainInventory[];
+  recentActivity: PersonalDataActivity[];
+};
+
+type PersonalDataActivity = {
+  id: string;
+  domain: PersonalDataDomain;
+  name: string;
+  occurredAt: string;
+  action: 'updated' | 'deleted';
 };
 
 const domainNames: Record<PersonalDataDomain, string> = {
@@ -38,7 +47,10 @@ const domainNames: Record<PersonalDataDomain, string> = {
   anchor: 'Anchor',
 };
 
-export function buildPersonalDataInventory(value: unknown): PersonalDataInventory {
+export function buildPersonalDataInventory(
+  value: unknown,
+  activityValue?: unknown
+): PersonalDataInventory {
   const payload = record(value);
   const summaries = Array.isArray(payload?.summaries) ? payload.summaries : null;
   if (!payload || !summaries) return unavailablePersonalDataInventory();
@@ -47,6 +59,7 @@ export function buildPersonalDataInventory(value: unknown): PersonalDataInventor
     generatedAt: text(payload.generatedAt),
     source: text(payload.source),
     status: 'connected',
+    recentActivity: buildRecentActivity(activityValue),
     domains: personalDataDomains.map((domain) => {
       const summary = summaries.map(record).find((item) => item?.domain === domain) ?? null;
       return domain === 'calorie'
@@ -71,7 +84,36 @@ export function unavailablePersonalDataInventory(): PersonalDataInventory {
       source: null,
       status: 'unavailable',
     })),
+    recentActivity: [],
   };
+}
+
+function buildRecentActivity(value: unknown): PersonalDataActivity[] {
+  const payload = record(value);
+  const items = Array.isArray(payload?.items) ? payload.items : [];
+  return items
+    .flatMap((value) => {
+      const item = record(value);
+      const domain = item?.domain;
+      const id = text(item?.id);
+      const occurredAt = text(item?.occurredAt);
+      const eventType = text(item?.eventType);
+      if (!isPersonalDataDomain(domain) || !id || !occurredAt || !eventType) return [];
+      return [
+        {
+          id,
+          domain,
+          name: domainNames[domain],
+          occurredAt,
+          action: eventType.endsWith('.deleted') ? ('deleted' as const) : ('updated' as const),
+        },
+      ];
+    })
+    .slice(0, 8);
+}
+
+function isPersonalDataDomain(value: unknown): value is PersonalDataDomain {
+  return typeof value === 'string' && personalDataDomains.includes(value as PersonalDataDomain);
 }
 
 function platformDomainInventory(

--- a/src/server/personal-platform-live.test.ts
+++ b/src/server/personal-platform-live.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { LiveReadError, parseLiveReadQuery } from './personal-platform-live';
+
+describe('Personal Platform Live reads', () => {
+  it('bounds pagination and keeps sensitive fields opt-in', () => {
+    const query = parseLiveReadQuery(
+      new URL(
+        'https://significanthobbies.com/api/personal-platform/live/records?start=2026-01-01&end=2028-12-31&q=Kyoto&limit=10&includeSensitive=true'
+      )
+    );
+    expect(query).toEqual({
+      q: 'Kyoto',
+      startYear: 2026,
+      endYear: 2028,
+      limit: 10,
+      offset: 0,
+      includeSensitive: true,
+    });
+  });
+
+  it('rejects invalid ranges and unbounded pages', () => {
+    expect(() =>
+      parseLiveReadQuery(
+        new URL(
+          'https://significanthobbies.com/api/personal-platform/live/records?start=2028&end=2026'
+        )
+      )
+    ).toThrow(LiveReadError);
+    expect(() =>
+      parseLiveReadQuery(
+        new URL('https://significanthobbies.com/api/personal-platform/live/records?limit=500')
+      )
+    ).toThrow(LiveReadError);
+  });
+});

--- a/src/server/personal-platform-live.ts
+++ b/src/server/personal-platform-live.ts
@@ -1,0 +1,168 @@
+import { and, count, desc, eq, gte, like, lte, or, type SQL } from 'drizzle-orm';
+
+import { bucketListItems } from '@/db/schema';
+import { db } from '@/server/db';
+
+const MAX_PAGE_SIZE = 50;
+
+export interface LiveReadQuery {
+  q?: string;
+  startYear?: number;
+  endYear?: number;
+  limit: number;
+  offset: number;
+  includeSensitive: boolean;
+}
+
+export function parseLiveReadQuery(url: URL): LiveReadQuery {
+  const startYear = year(url.searchParams.get('start'));
+  const endYear = year(url.searchParams.get('end'));
+  if (startYear && endYear && startYear > endYear) {
+    throw new LiveReadError('INVALID_RANGE', 'Start must not be after end.');
+  }
+  return {
+    q: url.searchParams.get('q')?.trim().slice(0, 200) || undefined,
+    startYear,
+    endYear,
+    limit: boundedInteger(url.searchParams.get('limit'), 20, 1, MAX_PAGE_SIZE),
+    offset: boundedInteger(url.searchParams.get('offset'), 0, 0, 1_000_000),
+    includeSensitive: url.searchParams.get('includeSensitive') === 'true',
+  };
+}
+
+export async function readLiveSummary(userId: string) {
+  const [total, latest] = await Promise.all([
+    db.select({ value: count() }).from(bucketListItems).where(eq(bucketListItems.userId, userId)),
+    db
+      .select({
+        id: bucketListItems.id,
+        title: bucketListItems.title,
+        status: bucketListItems.status,
+        category: bucketListItems.category,
+        targetYear: bucketListItems.targetYear,
+        updatedAt: bucketListItems.updatedAt,
+      })
+      .from(bucketListItems)
+      .where(eq(bucketListItems.userId, userId))
+      .orderBy(desc(bucketListItems.updatedAt), desc(bucketListItems.id))
+      .limit(1),
+  ]);
+  const latestItem = latest[0];
+  return {
+    domain: 'live',
+    source: 'significant-hobbies-service',
+    status: 'connected',
+    activeCount: total[0]?.value ?? 0,
+    latest: latestItem
+      ? {
+          id: latestItem.id,
+          title: latestItem.title,
+          status: latestItem.status,
+          category: latestItem.category,
+          targetYear: latestItem.targetYear,
+        }
+      : null,
+    lastUpdatedAt: latestItem?.updatedAt.toISOString() ?? null,
+  };
+}
+
+export async function readLiveRecords(userId: string, query: LiveReadQuery) {
+  return loadLiveRecords(userId, query);
+}
+
+function liveRecordConditions(userId: string, query: LiveReadQuery): SQL[] {
+  const conditions: SQL[] = [eq(bucketListItems.userId, userId)];
+  if (query.startYear) conditions.push(gte(bucketListItems.targetYear, query.startYear));
+  if (query.endYear) conditions.push(lte(bucketListItems.targetYear, query.endYear));
+  if (!query.q) return conditions;
+
+  const pattern = `%${escapeLike(query.q)}%`;
+  const search = or(
+    like(bucketListItems.title, pattern),
+    like(bucketListItems.category, pattern),
+    like(bucketListItems.status, pattern),
+    ...(query.includeSensitive ? [like(bucketListItems.description, pattern)] : [])
+  );
+  if (search) conditions.push(search);
+  return conditions;
+}
+
+export class LiveReadError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function year(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value.slice(0, 4));
+  if (!Number.isInteger(parsed) || parsed < 1900 || parsed > 2200) {
+    throw new LiveReadError('INVALID_RANGE', 'Choose a valid year range.');
+  }
+  return parsed;
+}
+
+function boundedInteger(value: string | null, fallback: number, minimum: number, maximum: number) {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new LiveReadError('INVALID_PAGINATION', `Choose a value from ${minimum} to ${maximum}.`);
+  }
+  return parsed;
+}
+
+function escapeLike(value: string) {
+  return value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_');
+}
+
+async function loadLiveRecords(userId: string, query: LiveReadQuery) {
+  const where = and(...liveRecordConditions(userId, query));
+  const [rows, total] = await Promise.all([
+    db
+      .select({
+        id: bucketListItems.id,
+        title: bucketListItems.title,
+        description: bucketListItems.description,
+        category: bucketListItems.category,
+        status: bucketListItems.status,
+        targetYear: bucketListItems.targetYear,
+        completedAt: bucketListItems.completedAt,
+        createdAt: bucketListItems.createdAt,
+        updatedAt: bucketListItems.updatedAt,
+      })
+      .from(bucketListItems)
+      .where(where)
+      .orderBy(desc(bucketListItems.updatedAt), desc(bucketListItems.id))
+      .limit(query.limit)
+      .offset(query.offset),
+    db.select({ value: count() }).from(bucketListItems).where(where),
+  ]);
+  const totalCount = total[0]?.value ?? 0;
+  return {
+    domain: 'live',
+    source: 'significant-hobbies-service',
+    generatedAt: new Date().toISOString(),
+    items: rows.map((row) => ({
+      id: row.id,
+      occurredAt: row.completedAt?.toISOString() ?? null,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+      record: {
+        title: row.title,
+        status: row.status,
+        category: row.category,
+        targetYear: row.targetYear,
+        ...(query.includeSensitive && row.description ? { description: row.description } : {}),
+      },
+    })),
+    page: {
+      limit: query.limit,
+      offset: query.offset,
+      total: totalCount,
+      nextOffset: query.offset + query.limit < totalCount ? query.offset + query.limit : null,
+    },
+  };
+}

--- a/src/server/personal-platform.ts
+++ b/src/server/personal-platform.ts
@@ -14,22 +14,29 @@ export async function getPersonalDataInventory(): Promise<PersonalDataInventory 
   if (!session?.session.token) return null;
 
   try {
-    const response = await fetch(personalPlatformTodayURL(), {
-      cache: 'no-store',
+    const request = {
+      cache: 'no-store' as const,
       signal: AbortSignal.timeout(4_000),
       headers: {
         Accept: 'application/json',
         Authorization: `Bearer ${session.session.token}`,
       },
-    });
-    if (!response.ok) return unavailablePersonalDataInventory();
-    return buildPersonalDataInventory(await response.json());
+    };
+    const [todayResponse, activityResponse] = await Promise.all([
+      fetch(personalPlatformURL('/v1/life/today'), request),
+      fetch(personalPlatformURL('/v1/life/events?limit=8'), request),
+    ]);
+    if (!todayResponse.ok) return unavailablePersonalDataInventory();
+    return buildPersonalDataInventory(
+      await todayResponse.json(),
+      activityResponse.ok ? await activityResponse.json() : undefined
+    );
   } catch {
     return unavailablePersonalDataInventory();
   }
 }
 
-function personalPlatformTodayURL(): string {
+function personalPlatformURL(path: string): string {
   const baseURL = process.env.PERSONAL_PLATFORM_URL?.trim() || DEFAULT_PERSONAL_PLATFORM_URL;
-  return new URL('/v1/life/today', baseURL).toString();
+  return new URL(path, baseURL).toString();
 }


### PR DESCRIPTION
## Summary
- expose typed Live summary and record reads
- backfill all Journal entries through PersonalSyncKit
- extend the Hub proof surface with privacy-safe recent sync metadata
- keep sensitive record text out of the aggregate dashboard

Part of https://github.com/Significant-Hobbies/personal-platform/issues/17

## Checks
- pnpm quality:web
- focused native unit and adapter tests

## Note
The full native UI run encountered simulator focus and busy-state failures after unit and adapter tests passed.