### PR TITLE
Keep Journal onboarding success visible after save

### DIFF
--- a/ios/Sources/SignificantHobbies/AppModel.swift
+++ b/ios/Sources/SignificantHobbies/AppModel.swift
@@ -54,7 +54,7 @@ final class AppModel {
             }
             if arguments.contains("--onboarding-demo") {
                 document = AtlasDocument()
-                forceJournalOnboarding = true
+                forceJournalOnboarding = !arguments.contains("--onboarding-production-policy")
             } else {
                 document = arguments.contains("--fresh-demo") ? .sample : try await store.load()
             }

--- a/ios/Sources/SignificantHobbies/RootView.swift
+++ b/ios/Sources/SignificantHobbies/RootView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct RootView: View {
     @Environment(AppModel.self) private var model
     @AppStorage(JournalOnboardingPreferences.completedKey) private var onboardingCompleted = false
+    @State private var isOnboardingSessionActive = false
 
     var body: some View {
         @Bindable var model = model
@@ -11,10 +12,12 @@ struct RootView: View {
             if model.isLoading {
                 ProgressView("Opening your Journal…")
             } else if model.isDataAvailable {
-                if model.shouldPresentJournalOnboarding(completed: onboardingCompleted) {
+                if isOnboardingSessionActive || model.shouldPresentJournalOnboarding(completed: onboardingCompleted) {
                     JournalOnboardingView {
                         onboardingCompleted = true
+                        isOnboardingSessionActive = false
                     }
+                    .onAppear { isOnboardingSessionActive = true }
                 } else {
                     JournalView()
                 }

--- a/ios/Tests/SignificantHobbiesUITests/SignificantHobbiesUITests.swift
+++ b/ios/Tests/SignificantHobbiesUITests/SignificantHobbiesUITests.swift
@@ -20,7 +20,7 @@ final class SignificantHobbiesUITests: XCTestCase {
 
     func testFirstEntryOnboardingSavesIntoTheRealJournal() {
         let app = XCUIApplication()
-        app.launchArguments = ["--onboarding-demo", "--reset-onboarding"]
+        app.launchArguments = ["--onboarding-demo", "--onboarding-production-policy", "--reset-onboarding"]
         app.launch()
 
         XCTAssertTrue(app.staticTexts["A private room for what matters."].waitForExistence(timeout: 3))


### PR DESCRIPTION
Closes a production-policy gap found while applying the same onboarding contract to Calorie.

The onboarding policy correctly bypasses existing writing on future launches, but that same observation could remove the active onboarding view immediately after the first save. This latches the current onboarding session until the owner opens Journal and adds a UI journey that exercises the real production policy rather than the forced evidence path.

Verification: focused UI journey passed on iPhone 17 Pro simulator.

No deployment or Apple release is included.