### PR TITLE
Show Calorie count and freshness in Hub

### DIFF
--- a/services/hub-backend/src/calorie.ts
+++ b/services/hub-backend/src/calorie.ts
@@ -61,11 +61,15 @@ export async function getCalorieToday(
       },
     });
     if (!response.ok) return unavailableSummary(`upstream_${response.status}`);
+    const summary = (await response.json()) as Record<string, unknown>;
     return {
       domain: "calorie",
       source: "calorie-service",
       status: "connected",
-      summary: await response.json(),
+      activeCount: typeof summary.entryCount === "number" ? summary.entryCount : 0,
+      lastUpdatedAt:
+        typeof summary.lastUpdatedAt === "string" ? summary.lastUpdatedAt : null,
+      summary,
     };
   } catch {
     return unavailableSummary("upstream_unreachable");

--- a/services/hub-backend/test/calorie.test.ts
+++ b/services/hub-backend/test/calorie.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { forwardCalorie } from "../src/calorie";
+import { forwardCalorie, getCalorieToday } from "../src/calorie";
 
 describe("Calorie connector", () => {
   it("forwards through the service binding with verified identity", async () => {
@@ -26,5 +26,37 @@ describe("Calorie connector", () => {
     expect(forwarded?.url).toBe("https://calorie.internal/v1/personal/summary");
     expect(forwarded?.headers.get("X-Personal-User-Id")).toBe("user-123");
     expect(forwarded?.headers.get("Authorization")).toBe("Bearer private-client-token");
+  });
+
+  it("promotes count and freshness into the Hub card contract", async () => {
+    const env = {
+      OWNER_TIMEZONE: "Asia/Kolkata",
+      CALORIE_SERVICE: {
+        fetch: async () =>
+          Response.json({
+            entryCount: 3,
+            totals: { calories: 1_420, proteinG: 86 },
+            lastUpdatedAt: "2026-08-23T00:30:00.000Z",
+          }),
+      },
+    } as unknown as Env;
+
+    const summary = await getCalorieToday(
+      new Request("https://significanthobbies.com/hub"),
+      env,
+      { id: "user-123" },
+    );
+
+    expect(summary).toMatchObject({
+      domain: "calorie",
+      source: "calorie-service",
+      status: "connected",
+      activeCount: 3,
+      lastUpdatedAt: "2026-08-23T00:30:00.000Z",
+      summary: {
+        entryCount: 3,
+        totals: { calories: 1_420, proteinG: 86 },
+      },
+    });
   });
 });

--- a/services/hub-backend/test/index.test.ts
+++ b/services/hub-backend/test/index.test.ts
@@ -293,7 +293,8 @@ describe("Hub Backend Worker", () => {
       body.summaries.filter(
         (summary) => typeof summary.activeCount === "number" && summary.activeCount >= 1,
       ),
-    ).toHaveLength(6);
+    ).toHaveLength(7);
+    expect(body.summaries.at(-1)?.activeCount).toBe(1);
     expect(body.summaries.at(-1)?.summary?.entryCount).toBe(1);
   });
 


### PR DESCRIPTION
Calorie already returns a useful semantic daily summary, but the Hub adapter kept its count and freshness nested. That meant a successfully linked Calorie card could only say `Connected`.

This promotes `entryCount` and `lastUpdatedAt` into the common Hub card contract while retaining the exact typed Calorie summary for API and MCP consumers.

Verification:
- `npm --prefix services/hub-backend run check`
- 21 Worker tests pass
- Wrangler production bundle dry-run succeeds

Part of #142
