### PR TITLE
Expose pending sync mutation count

### DIFF
--- a/Sources/PersonalSyncKit/PersonalSyncRuntime.swift
+++ b/Sources/PersonalSyncKit/PersonalSyncRuntime.swift
@@ -100,6 +100,13 @@ public actor PersonalSyncRuntime {
         try await fingerprints.setFingerprint(fingerprint, for: recordId, in: domain)
     }
 
+    /// Number of durable local mutations still waiting for this domain.
+    /// Apps use this to distinguish a healthy, current connection from a
+    /// signed-out or failed sync that is safely retaining local changes.
+    public func pendingMutationCount() async -> Int {
+        await outbox.pending(for: domain).count
+    }
+
     /// Returns immediately with no changes while signed out. Network failures
     /// are surfaced to the app, while the durable outbox remains intact.
     public func synchronize() async throws -> [SyncChange] {

--- a/Tests/PersonalSyncKitTests/PersonalSyncRuntimeTests.swift
+++ b/Tests/PersonalSyncKitTests/PersonalSyncRuntimeTests.swift
@@ -35,7 +35,9 @@ private actor RuntimeTokenStore: PersonalBearerTokenStore {
         record: JSONValue.object(["personId": JSONValue.string("person-2")])
     )
 
+    #expect(await runtime.pendingMutationCount() == 1)
     #expect(try await runtime.synchronize().isEmpty)
+    #expect(await runtime.pendingMutationCount() == 1)
     let stored = try JSONDecoder().decode(
         [OutboxEntry].self,
         from: Data(contentsOf: directory.appending(path: "personal-sync-outbox.json"))


### PR DESCRIPTION
Part of #141.

Adds a read-only `PersonalSyncRuntime.pendingMutationCount()` primitive so native apps can distinguish fully synced state from locally queued changes. The durable outbox and synchronization behavior are unchanged.

Verification: `npm run test:swift` — 12 tests passed; `git diff --check` passed.