### PR TITLE
feat: pin Google web sign-in to an existing Mac window

### DIFF
--- a/Sources/PersonalSyncKit/PersonalIdentityClient.swift
+++ b/Sources/PersonalSyncKit/PersonalIdentityClient.swift
@@ -37,6 +37,7 @@ public struct PersonalIdentitySession: Codable, Equatable, Sendable {
 public enum PersonalIdentityError: LocalizedError, Equatable, Sendable {
     case missingSession
     case invalidResponse
+    case unavailablePresentationContext
     case server(status: Int, message: String)
     case keychain(status: Int32)
 
@@ -44,6 +45,8 @@ public enum PersonalIdentityError: LocalizedError, Equatable, Sendable {
         switch self {
         case .missingSession: "Sign in again to connect this app."
         case .invalidResponse: "The personal account service returned an invalid response."
+        case .unavailablePresentationContext:
+            "Open the app window and try Google sign-in again."
         case let .server(_, message): message
         case .keychain: "The secure account session could not be accessed."
         }

--- a/Sources/PersonalSyncKit/PersonalWebSignInModel.swift
+++ b/Sources/PersonalSyncKit/PersonalWebSignInModel.swift
@@ -9,6 +9,11 @@ import UIKit
 import AppKit
 #endif
 
+public typealias PersonalWebAuthenticator = @MainActor @Sendable (
+    _ url: URL,
+    _ callbackScheme: String
+) async throws -> URL
+
 @MainActor
 @Observable
 public final class PersonalAccountModel: NSObject,
@@ -22,6 +27,9 @@ public final class PersonalAccountModel: NSObject,
     private let callbackScheme: String
     private let identityURL: URL
     private var webSession: ASWebAuthenticationSession?
+    #if os(macOS)
+    private var browserPresentationWindow: NSWindow?
+    #endif
     private var rawAppleNonce: String?
 
     public init(
@@ -49,11 +57,40 @@ public final class PersonalAccountModel: NSObject,
     }
 
     public func connectWithGoogle() async {
+        await completeGoogleConnection {
+            try await self.authenticateInBrowser()
+        }
+    }
+
+    /// Uses a browser session supplied by the presenting view. SwiftUI's
+    /// environment-backed session keeps the authentication presentation tied
+    /// to the window that initiated it instead of rediscovering a Mac window
+    /// from a long-lived account model.
+    public func connectWithGoogle(using authenticate: PersonalWebAuthenticator) async {
+        await completeGoogleConnection {
+            let callbackURL = try await authenticate(
+                Self.googleAuthenticationURL(
+                    identityURL: self.identityURL,
+                    callbackScheme: self.callbackScheme
+                ),
+                self.callbackScheme
+            )
+            return try Self.browserHandoffCode(
+                from: callbackURL,
+                error: nil,
+                expectedScheme: self.callbackScheme
+            )
+        }
+    }
+
+    private func completeGoogleConnection(
+        using authenticationCode: @MainActor () async throws -> String
+    ) async {
         guard !isConnecting else { return }
         isConnecting = true
         defer { isConnecting = false }
         do {
-            let code = try await authenticateInBrowser()
+            let code = try await authenticationCode()
             session = try await identity.exchangeBrowserHandoff(code)
             errorMessage = nil
         } catch let error as ASWebAuthenticationSessionError
@@ -125,21 +162,38 @@ public final class PersonalAccountModel: NSObject,
             .flatMap(\.windows)
             .first(where: \.isKeyWindow) ?? ASPresentationAnchor()
         #elseif os(macOS)
-        return NSApplication.shared.keyWindow ?? NSWindow()
+        return browserPresentationWindow
+            ?? Self.preferredPresentationWindow(
+                keyWindow: NSApplication.shared.keyWindow,
+                mainWindow: NSApplication.shared.mainWindow,
+                visibleWindow: NSApplication.shared.windows.first(where: { $0.isVisible })
+            )
+            ?? ASPresentationAnchor()
         #endif
     }
 
     private func authenticateInBrowser() async throws -> String {
-        var components = URLComponents(
-            url: identityURL.appending(path: "api/native/auth/google/start"),
-            resolvingAgainstBaseURL: false
-        )!
-        components.queryItems = [
-            URLQueryItem(name: "callback", value: "\(callbackScheme)://auth"),
-        ]
-        let url = components.url!
+        let url = Self.googleAuthenticationURL(
+            identityURL: identityURL,
+            callbackScheme: callbackScheme
+        )
         let expectedCallbackScheme = callbackScheme
-        defer { webSession = nil }
+        #if os(macOS)
+        guard let presentationWindow = Self.preferredPresentationWindow(
+            keyWindow: NSApplication.shared.keyWindow,
+            mainWindow: NSApplication.shared.mainWindow,
+            visibleWindow: NSApplication.shared.windows.first(where: { $0.isVisible })
+        ) else {
+            throw PersonalIdentityError.unavailablePresentationContext
+        }
+        browserPresentationWindow = presentationWindow
+        #endif
+        defer {
+            webSession = nil
+            #if os(macOS)
+            browserPresentationWindow = nil
+            #endif
+        }
         return try await withCheckedThrowingContinuation { continuation in
             // AuthenticationServices may invoke this closure on Safari's XPC
             // executor. Keep it nonisolated: resuming a checked continuation is
@@ -172,6 +226,30 @@ public final class PersonalAccountModel: NSObject,
             }
         }
     }
+
+    nonisolated static func googleAuthenticationURL(
+        identityURL: URL,
+        callbackScheme: String
+    ) -> URL {
+        var components = URLComponents(
+            url: identityURL.appending(path: "api/native/auth/google/start"),
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [
+            URLQueryItem(name: "callback", value: "\(callbackScheme)://auth"),
+        ]
+        return components.url!
+    }
+
+    #if os(macOS)
+    static func preferredPresentationWindow(
+        keyWindow: NSWindow?,
+        mainWindow: NSWindow?,
+        visibleWindow: NSWindow?
+    ) -> NSWindow? {
+        keyWindow ?? mainWindow ?? visibleWindow
+    }
+    #endif
 
     nonisolated static func browserHandoffCode(
         from callbackURL: URL?,

--- a/Tests/PersonalSyncKitTests/PersonalIdentityClientTests.swift
+++ b/Tests/PersonalSyncKitTests/PersonalIdentityClientTests.swift
@@ -148,6 +148,50 @@ struct PersonalIdentityClientTests {
         #expect(identity.userId == "shared-user")
         #expect(await store.load() == "handoff-token")
     }
+
+    #if canImport(AuthenticationServices) && (os(iOS) || os(macOS))
+    @Test("Completes Google sign-in through a view-scoped browser session")
+    @MainActor
+    func viewScopedGoogleAuthenticationCompletesHandoff() async throws {
+        IdentityURLProtocol.handler = { request in
+            if request.url?.path == "/api/native/auth/exchange" {
+                return (
+                    try response(request, status: 200),
+                    Data(#"{"token":"view-scoped-token"}"#.utf8)
+                )
+            }
+            #expect(request.url?.path == "/api/personal-platform/session")
+            return (
+                try response(request, status: 200),
+                Data(#"{"userId":"shared-user","email":"owner@example.com","appleSubject":null}"#.utf8)
+            )
+        }
+        let client = PersonalIdentityClient(
+            baseURL: try #require(URL(string: "https://identity.test")),
+            session: testSession(),
+            tokenStore: MemoryBearerStore()
+        )
+        let account = PersonalAccountModel(
+            identity: client,
+            callbackScheme: "anchor",
+            identityURL: try #require(URL(string: "https://identity.test"))
+        )
+
+        await account.connectWithGoogle { url, callbackScheme in
+            #expect(url.path == "/api/native/auth/google/start")
+            #expect(
+                URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                    .queryItems?.first(where: { $0.name == "callback" })?.value
+                    == "anchor://auth"
+            )
+            #expect(callbackScheme == "anchor")
+            return try #require(URL(string: "anchor://auth?code=one-use-code"))
+        }
+
+        #expect(account.session?.email == "owner@example.com")
+        #expect(account.errorMessage == nil)
+    }
+    #endif
 }
 
 private func testSession() -> URLSession {

--- a/Tests/PersonalSyncKitTests/PersonalWebSignInModelTests.swift
+++ b/Tests/PersonalSyncKitTests/PersonalWebSignInModelTests.swift
@@ -2,6 +2,9 @@
 import Foundation
 import Testing
 @testable import PersonalSyncKit
+#if os(macOS)
+import AppKit
+#endif
 
 @Suite("Personal web sign in")
 struct PersonalWebSignInModelTests {
@@ -38,5 +41,44 @@ struct PersonalWebSignInModelTests {
             )
         }
     }
+
+    #if os(macOS)
+    @Test("Pins Google sign-in to an existing Mac window")
+    @MainActor
+    func selectsExistingMacPresentationWindow() {
+        let keyWindow = NSWindow()
+        let mainWindow = NSWindow()
+        let visibleWindow = NSWindow()
+
+        #expect(
+            PersonalAccountModel.preferredPresentationWindow(
+                keyWindow: keyWindow,
+                mainWindow: mainWindow,
+                visibleWindow: visibleWindow
+            ) === keyWindow
+        )
+        #expect(
+            PersonalAccountModel.preferredPresentationWindow(
+                keyWindow: nil,
+                mainWindow: mainWindow,
+                visibleWindow: visibleWindow
+            ) === mainWindow
+        )
+        #expect(
+            PersonalAccountModel.preferredPresentationWindow(
+                keyWindow: nil,
+                mainWindow: nil,
+                visibleWindow: visibleWindow
+            ) === visibleWindow
+        )
+        #expect(
+            PersonalAccountModel.preferredPresentationWindow(
+                keyWindow: nil,
+                mainWindow: nil,
+                visibleWindow: nil
+            ) == nil
+        )
+    }
+    #endif
 }
 #endif

--- a/services/hub-backend/src/hub.ts
+++ b/services/hub-backend/src/hub.ts
@@ -217,7 +217,7 @@ function page(summaries: Map<string, Record<string, unknown>> | null, origin: st
       <p class="footer-fineprint">Each app owns its interface and immediate data. The Hub shows privacy-safe summaries through documented contracts.</p>
     </footer>
     <script src="https://sassmaker.com/project-strip.js" data-project="significanthobbies" defer></script>
-    <script src="https://sassmaker.com/ai-chat-footer.js" data-name="Significant Hobbies" data-compose="false" defer></script>
+    <script src="https://sassmaker.com/ai-chat-footer.js" data-name="Significant Hobbies" defer></script>
   </body>
 </html>`;
 }


### PR DESCRIPTION
ASWebAuthenticationSession needs a presentation anchor on macOS; the
old fallback to NSApplication.shared.keyWindow could present against a
freshly created empty window. Add a view-scoped authenticator overload
and a preferredPresentationWindow helper so the session ties to the
window that started the sign-in. Also drop the data-compose="false"
flag from the hub footer chat widget.

Generated with [Devin](https://devin.ai)

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>
